### PR TITLE
fix: address layout and form control bugs

### DIFF
--- a/app/firm/[firmId]/client/[clientId]/page.tsx
+++ b/app/firm/[firmId]/client/[clientId]/page.tsx
@@ -345,7 +345,7 @@ export default function ClientDetailPage({
                     <FormLabel>發票類型</FormLabel>
                     <Select 
                       onValueChange={field.onChange}
-                      defaultValue={field.value}
+                      value={field.value}
                     >
                       <FormControl>
                         <SelectTrigger>

--- a/components/invoice-table.tsx
+++ b/components/invoice-table.tsx
@@ -113,14 +113,14 @@ export function InvoiceTable({
         <TableBody>
           {isLoading ? (
             <TableRow>
-              <TableCell colSpan={showClientColumn ? 6 : 5} className="h-24 text-center">
+              <TableCell colSpan={showClientColumn ? 7 : 6} className="h-24 text-center">
                 <Loader2 className="h-6 w-6 animate-spin mx-auto text-muted-foreground" />
               </TableCell>
             </TableRow>
           ) : invoices.length === 0 ? (
             <TableRow>
               <TableCell
-                colSpan={showClientColumn ? 6 : 5}
+                colSpan={showClientColumn ? 7 : 6}
                 className="h-24 text-center text-muted-foreground"
               >
                 無發票資料。


### PR DESCRIPTION
- Fix colSpan calculation in InvoiceTable to account for the new "所屬期別" column, preventing broken placeholder rows.
- Convert the invoice type Select in the client detail page upload form from uncontrolled (defaultValue) to controlled (value) for proper react-hook-form integration.