### PR TITLE
fix: clean up client portal UI labels

### DIFF
--- a/app/firm/[firmId]/layout.tsx
+++ b/app/firm/[firmId]/layout.tsx
@@ -90,9 +90,6 @@ export default function FirmIdLayout({
             className="mr-2 hidden h-4 md:block"
           />
           <div className="flex items-center gap-2 px-4">
-            <span className="text-sm font-medium text-muted-foreground">
-              用戶:
-            </span>
             <Suspense
               fallback={
                 <div className="h-4 w-32 bg-muted animate-pulse rounded" />

--- a/components/portal-sidebar.tsx
+++ b/components/portal-sidebar.tsx
@@ -41,7 +41,7 @@ export function PortalSidebar() {
                   <LayoutDashboard className="size-4" />
                 </div>
                 <div className="grid flex-1 text-left text-sm leading-tight">
-                  <span className="truncate font-semibold text-lg">Client Portal</span>
+                  <span className="truncate font-semibold text-lg">客戶中心</span>
                 </div>
               </Link>
             </SidebarMenuButton>


### PR DESCRIPTION
## Summary
- Remove redundant "用戶:" prefix from the portal header bar
- Rename "Client Portal" to "客戶中心" in the sidebar for consistent Traditional Chinese UI

## Test plan
- [ ] Open the client portal as a client user
- [ ] Verify the header no longer shows "用戶:" before the user name
- [ ] Verify the sidebar title reads "客戶中心"

🤖 Generated with [Claude Code](https://claude.com/claude-code)