### PR TITLE
feat: add tax calendar reminders to client portal

### DIFF
--- a/app/firm/[firmId]/client/[clientId]/portal/loading.tsx
+++ b/app/firm/[firmId]/client/[clientId]/portal/loading.tsx
@@ -11,6 +11,7 @@ export default function PortalDashboardLoading() {
         <Skeleton className="h-6 w-40" />
         <Skeleton className="h-4 w-64" />
         <Skeleton className="h-36 w-full rounded-2xl" />
+        <Skeleton className="h-12 w-full rounded-2xl" />
       </div>
 
       {/* Secondary periods */}

--- a/app/firm/[firmId]/client/[clientId]/portal/page.tsx
+++ b/app/firm/[firmId]/client/[clientId]/portal/page.tsx
@@ -21,6 +21,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { TaxCalendarReminder } from "@/components/tax-calendar-reminder";
 
 export default function PortalDashboardPage({
   params,
@@ -197,6 +198,7 @@ export default function PortalDashboardPage({
                 variant="primary"
                 actionLabel="上傳本期資料"
               />
+              <TaxCalendarReminder />
             </section>
           ) : null}
 

--- a/components/tax-calendar-reminder.tsx
+++ b/components/tax-calendar-reminder.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useMemo } from "react";
+import { CalendarDays } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { getUpcomingTaxEvents, type UpcomingTaxEvent } from "@/lib/domain/tax-calendar";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { Badge } from "@/components/ui/badge";
+
+function urgencyColor(daysUntil: number) {
+  if (daysUntil < 7) return "border-rose-200 bg-rose-50 text-rose-700";
+  if (daysUntil <= 30) return "border-amber-200 bg-amber-50 text-amber-700";
+  return "border-emerald-200 bg-emerald-50 text-emerald-700";
+}
+
+function formatDate(event: UpcomingTaxEvent) {
+  return `${event.date.getMonth() + 1}/${event.date.getDate()}`;
+}
+
+function daysLabel(days: number) {
+  if (days === 0) return "今天";
+  return `${days} 天後`;
+}
+
+export function TaxCalendarReminder() {
+  const { events, nextEvent } = useMemo(() => {
+    const all = getUpcomingTaxEvents();
+    return { events: all, nextEvent: all.find((e) => e.isNext) };
+  }, []);
+
+  if (!nextEvent) return null;
+
+  return (
+    <Accordion type="single" collapsible>
+      <AccordionItem value="tax-calendar" className="border-0">
+        <div className="rounded-2xl border border-slate-200/80 bg-white shadow-sm">
+          <AccordionTrigger className="px-4 py-3 hover:no-underline">
+            <div className="flex items-center gap-2">
+              <CalendarDays className="h-4 w-4 text-slate-500" />
+              <span className="text-sm font-medium text-slate-700">
+                下次截止：{formatDate(nextEvent)} {nextEvent.label}
+              </span>
+              <Badge
+                variant="outline"
+                className={cn(
+                  "rounded-full px-2 py-0 text-xs font-medium",
+                  urgencyColor(nextEvent.daysUntil),
+                )}
+              >
+                {daysLabel(nextEvent.daysUntil)}
+              </Badge>
+            </div>
+          </AccordionTrigger>
+
+          <AccordionContent className="px-4">
+            <div className="space-y-1">
+              {events.map((event) => (
+                <div
+                  key={`${event.month}-${event.day}-${event.label}`}
+                  className={cn(
+                    "flex items-center gap-3 rounded-lg px-3 py-2 text-sm",
+                    event.isNext
+                      ? "border-l-2 border-emerald-500 bg-emerald-50/60 font-medium text-slate-900"
+                      : "text-slate-600",
+                  )}
+                >
+                  <span className="w-12 shrink-0 tabular-nums">
+                    {formatDate(event)}
+                  </span>
+                  <span className="flex-1">{event.label}</span>
+                  {event.isNext && (
+                    <Badge
+                      variant="outline"
+                      className={cn(
+                        "rounded-full px-2 py-0 text-xs",
+                        urgencyColor(event.daysUntil),
+                      )}
+                    >
+                      {daysLabel(event.daysUntil)}
+                    </Badge>
+                  )}
+                </div>
+              ))}
+            </div>
+          </AccordionContent>
+        </div>
+      </AccordionItem>
+    </Accordion>
+  );
+}

--- a/components/tax-calendar-reminder.tsx
+++ b/components/tax-calendar-reminder.tsx
@@ -28,12 +28,14 @@ function daysLabel(days: number) {
 }
 
 export function TaxCalendarReminder() {
-  const { events, nextEvent } = useMemo(() => {
+  const { events, nextEvents } = useMemo(() => {
     const all = getUpcomingTaxEvents();
-    return { events: all, nextEvent: all.find((e) => e.isNext) };
+    return { events: all, nextEvents: all.filter((e) => e.isNext) };
   }, []);
 
-  if (!nextEvent) return null;
+  if (nextEvents.length === 0) return null;
+
+  const nextEvent = nextEvents[0];
 
   return (
     <Accordion type="single" collapsible>
@@ -43,7 +45,10 @@ export function TaxCalendarReminder() {
             <div className="flex items-center gap-2">
               <CalendarDays className="h-4 w-4 text-slate-500" />
               <span className="text-sm font-medium text-slate-700">
-                下次截止：{formatDate(nextEvent)} {nextEvent.label}
+                下次截止：{formatDate(nextEvent)}{" "}
+                {nextEvents.length === 1
+                  ? nextEvent.label
+                  : `${nextEvent.label} 等 ${nextEvents.length} 項`}
               </span>
               <Badge
                 variant="outline"

--- a/lib/domain/tax-calendar.test.ts
+++ b/lib/domain/tax-calendar.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { getUpcomingTaxEvents, TAX_EVENTS } from "./tax-calendar";
+
+describe("getUpcomingTaxEvents", () => {
+  it("returns all events with the nearest one marked isNext", () => {
+    // April 10 2026 — next event should be May 15 營業稅
+    const ref = new Date(2026, 3, 10); // month is 0-indexed
+    const events = getUpcomingTaxEvents(ref);
+
+    expect(events.length).toBe(TAX_EVENTS.length);
+    expect(events.filter((e) => e.isNext)).toHaveLength(1);
+
+    const next = events[0];
+    expect(next.isNext).toBe(true);
+    expect(next.label).toBe("營業稅");
+    expect(next.date.getMonth()).toBe(4); // May
+    expect(next.date.getDate()).toBe(15);
+    expect(next.daysUntil).toBe(35);
+  });
+
+  it("sorts events chronologically from the reference date", () => {
+    const ref = new Date(2026, 3, 10);
+    const events = getUpcomingTaxEvents(ref);
+
+    for (let i = 1; i < events.length; i++) {
+      expect(events[i].date.getTime()).toBeGreaterThanOrEqual(
+        events[i - 1].date.getTime(),
+      );
+    }
+  });
+
+  it("wraps past events to next year", () => {
+    // Dec 1 2026 — Jan 15 營業稅 should wrap to 2027
+    const ref = new Date(2026, 11, 1);
+    const events = getUpcomingTaxEvents(ref);
+
+    const next = events[0];
+    expect(next.isNext).toBe(true);
+    expect(next.date.getFullYear()).toBeGreaterThanOrEqual(2026);
+    // The nearest should be Nov 15 or later in 2026, or Jan next year
+    // Nov 15 2026 is before Dec 1, so it should wrap. Next is Jan 15 2027.
+    expect(next.label).toBe("營業稅");
+    expect(next.date.getFullYear()).toBe(2027);
+    expect(next.date.getMonth()).toBe(0); // January
+  });
+
+  it("adjusts weekend deadlines to Monday", () => {
+    // Jan 15 2028 is a Saturday — should adjust to Jan 17 (Monday)
+    const ref = new Date(2028, 0, 1);
+    const events = getUpcomingTaxEvents(ref);
+
+    const janBusinessTax = events.find(
+      (e) => e.label === "營業稅" && e.date.getMonth() === 0,
+    );
+    expect(janBusinessTax).toBeDefined();
+    expect(janBusinessTax!.date.getDay()).not.toBe(0); // not Sunday
+    expect(janBusinessTax!.date.getDay()).not.toBe(6); // not Saturday
+    // Jan 15 2028 is Saturday, so adjusted to Jan 17 Monday
+    expect(janBusinessTax!.date.getDate()).toBe(17);
+  });
+
+  it("handles reference date on the exact deadline day", () => {
+    // May 15 2026 is a Friday — event is today, daysUntil should be 0
+    const ref = new Date(2026, 4, 15);
+    const events = getUpcomingTaxEvents(ref);
+
+    const todayEvent = events.find(
+      (e) => e.daysUntil === 0 && e.label === "營業稅",
+    );
+    expect(todayEvent).toBeDefined();
+  });
+
+  it("marks only one event as isNext", () => {
+    const ref = new Date(2026, 0, 15); // Jan 15 — multiple events on this day
+    const events = getUpcomingTaxEvents(ref);
+
+    const nextEvents = events.filter((e) => e.isNext);
+    expect(nextEvents).toHaveLength(1);
+  });
+});

--- a/lib/domain/tax-calendar.test.ts
+++ b/lib/domain/tax-calendar.test.ts
@@ -70,11 +70,16 @@ describe("getUpcomingTaxEvents", () => {
     expect(todayEvent).toBeDefined();
   });
 
-  it("marks only one event as isNext", () => {
-    const ref = new Date(2026, 0, 15); // Jan 15 — multiple events on this day
+  it("marks all same-date events as isNext", () => {
+    // Jan 31 has 3 events: 各類所得扣繳, 補充保費, 股利憑單
+    // Jan 31 2026 is Saturday → adjusted to Feb 2 (Monday)
+    const ref = new Date(2026, 0, 31);
     const events = getUpcomingTaxEvents(ref);
 
     const nextEvents = events.filter((e) => e.isNext);
-    expect(nextEvents).toHaveLength(1);
+    expect(nextEvents).toHaveLength(3);
+    expect(
+      nextEvents.every((e) => e.date.getTime() === nextEvents[0].date.getTime()),
+    ).toBe(true);
   });
 });

--- a/lib/domain/tax-calendar.ts
+++ b/lib/domain/tax-calendar.ts
@@ -88,7 +88,11 @@ export function getUpcomingTaxEvents(
   upcoming.sort((a, b) => a.date.getTime() - b.date.getTime());
 
   if (upcoming.length > 0) {
-    upcoming[0].isNext = true;
+    const nextDate = upcoming[0].date.getTime();
+    for (const e of upcoming) {
+      if (e.date.getTime() !== nextDate) break;
+      e.isNext = true;
+    }
   }
 
   return upcoming;

--- a/lib/domain/tax-calendar.ts
+++ b/lib/domain/tax-calendar.ts
@@ -1,0 +1,95 @@
+export type TaxEvent = {
+  month: number;
+  day: number;
+  label: string;
+};
+
+export type UpcomingTaxEvent = TaxEvent & {
+  date: Date;
+  daysUntil: number;
+  isNext: boolean;
+};
+
+/**
+ * Static list of annual tax filing deadlines in Taiwan.
+ * Business tax (營業稅) recurs bimonthly on the 15th of odd months.
+ */
+export const TAX_EVENTS: TaxEvent[] = [
+  { month: 1, day: 15, label: "營業稅" },
+  { month: 1, day: 31, label: "各類所得扣繳" },
+  { month: 1, day: 31, label: "補充保費" },
+  { month: 1, day: 31, label: "股利憑單" },
+  { month: 3, day: 15, label: "營業稅" },
+  { month: 3, day: 22, label: "執行業務者扣繳憑單" },
+  { month: 3, day: 31, label: "公司法22-1" },
+  { month: 5, day: 15, label: "營業稅" },
+  { month: 5, day: 31, label: "所得稅" },
+  { month: 7, day: 15, label: "營業稅" },
+  { month: 9, day: 15, label: "營業稅" },
+  { month: 9, day: 30, label: "暫繳" },
+  { month: 11, day: 15, label: "營業稅" },
+];
+
+/**
+ * Adjust weekend dates to the next Monday (same logic as RocPeriod).
+ */
+function adjustWeekendToMonday(date: Date): Date {
+  const day = date.getDay();
+  if (day === 6) {
+    return new Date(date.getFullYear(), date.getMonth(), date.getDate() + 2);
+  }
+  if (day === 0) {
+    return new Date(date.getFullYear(), date.getMonth(), date.getDate() + 1);
+  }
+  return date;
+}
+
+function toDateOnly(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+function diffDays(a: Date, b: Date): number {
+  return Math.round(
+    (a.getTime() - b.getTime()) / (1000 * 60 * 60 * 24),
+  );
+}
+
+/**
+ * Get all upcoming tax events sorted by proximity from the reference date.
+ * Events whose adjusted deadline has already passed this year are wrapped
+ * to next year. The nearest event is marked `isNext: true`.
+ */
+export function getUpcomingTaxEvents(
+  referenceDate: Date = new Date(),
+): UpcomingTaxEvent[] {
+  const today = toDateOnly(referenceDate);
+  const year = today.getFullYear();
+
+  const upcoming: UpcomingTaxEvent[] = TAX_EVENTS.map((event) => {
+    let date = adjustWeekendToMonday(
+      new Date(year, event.month - 1, event.day),
+    );
+
+    // If the deadline has already passed this year, wrap to next year
+    if (date < today) {
+      date = adjustWeekendToMonday(
+        new Date(year + 1, event.month - 1, event.day),
+      );
+    }
+
+    return {
+      ...event,
+      date,
+      daysUntil: diffDays(date, today),
+      isNext: false,
+    };
+  });
+
+  upcoming.sort((a, b) => a.date.getTime() - b.date.getTime());
+
+  if (upcoming.length > 0) {
+    upcoming[0].isNext = true;
+  }
+
+  return upcoming;
+}


### PR DESCRIPTION
## Summary
- Add a collapsible tax calendar accordion below the primary period card on the client portal
- Shows the next upcoming tax deadline with urgency-colored badge (emerald >30d, amber 7-30d, rose <7d)
- Expand to see all annual events: 營業稅 (bimonthly), 所得稅, 暫繳, 各類所得扣繳, 補充保費, 股利憑單, 執行業務者扣繳憑單, 公司法22-1
- Weekend deadlines auto-adjust to Monday

## Test plan
- [ ] `npx vitest run lib/domain/tax-calendar.test.ts` — 6 unit tests pass (mid-year, year-end wrap, weekend adjustment, exact-day, single-isNext)
- [ ] `npm run type-check` — no type errors
- [ ] Visit client portal → collapsed accordion shows next deadline with days-until badge
- [ ] Expand accordion → full annual calendar listed chronologically
- [ ] Verify urgency badge color matches threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)