### PR TITLE
feat: add electronic invoice notice to portal and FAQ

### DIFF
--- a/app/(landing)/faq/data.tsx
+++ b/app/(landing)/faq/data.tsx
@@ -108,6 +108,11 @@ export const faqCategories: FaqCategory[] = [
         ),
       },
       {
+        question: "電子發票需要上傳嗎？",
+        answer:
+          "電子發票不需要拍照上傳。SnapBooks 會自動從財政部電子發票平台下載您的電子發票資料，您只需要上傳手開發票、收據等紙本憑證即可。",
+      },
+      {
         question: "會怎麼通知我相關事項呢？",
         answer:
           "我們會透過綁定 LINE 及 Email 的方式通知您，因此請留意相關訊息。",

--- a/app/firm/[firmId]/client/[clientId]/portal/page.tsx
+++ b/app/firm/[firmId]/client/[clientId]/portal/page.tsx
@@ -155,6 +155,11 @@ export default function PortalDashboardPage({
         </div>
       </section>
 
+      <div className="flex items-start gap-2.5 rounded-xl border border-sky-200/80 bg-sky-50/60 px-4 py-3 text-sm text-sky-800">
+        <Info className="mt-0.5 h-4 w-4 shrink-0 text-sky-500" />
+        <p>電子發票不需上傳圖檔，SnapBooks 會自動從電子發票平台下載。</p>
+      </div>
+
       {periods.length === 0 ? (
         <Card className="h-40 animate-pulse border-slate-200 bg-slate-100/70" />
       ) : (


### PR DESCRIPTION
## Summary
- Add info notice to client portal: 「電子發票不需上傳圖檔，SnapBooks 會自動從電子發票平台下載。」
- Add FAQ entry explaining that electronic invoices are auto-downloaded from 電子發票平台 and only paper invoices need uploading

## Test plan
- [ ] Check portal page at `/firm/{id}/client/{id}/portal` — info banner renders below hero section
- [ ] Check FAQ page at `/faq` — new question appears under "SnapBooks.ai 服務相關"
- [ ] Verify mobile layout looks good

🤖 Generated with [Claude Code](https://claude.com/claude-code)