### PR TITLE
feat: reuse FIA business name lookup across extraction and review flows

### DIFF
--- a/components/allowance-review-dialog.tsx
+++ b/components/allowance-review-dialog.tsx
@@ -39,6 +39,7 @@ import {
   CalendarIcon,
 } from "lucide-react";
 import { type Allowance } from "@/lib/domain/models";
+import { useTaxIdLookup } from "@/hooks/use-tax-id-lookup";
 import { updateAllowance } from "@/lib/services/allowance";
 import { toast } from "sonner";
 import { useState, useEffect, useCallback, useMemo } from "react";
@@ -186,6 +187,37 @@ export function AllowanceReviewDialog({
 
   const source = form.watch("source");
   const isExcelImport = source === "import-excel";
+
+  const sellerTaxId = form.watch("sellerTaxId");
+  const buyerTaxId = form.watch("buyerTaxId");
+
+  // Auto-lookup business names from FIA registry when tax IDs are present
+  const handleSellerNameLookup = useCallback(
+    (name: string) => {
+      form.setValue("sellerName", name);
+      const conf = form.getValues("confidence");
+      if (conf) form.setValue("confidence.sellerName", "high");
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+  const handleBuyerNameLookup = useCallback(
+    (name: string) => {
+      form.setValue("buyerName", name);
+      const conf = form.getValues("confidence");
+      if (conf) form.setValue("confidence.buyerName", "high");
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+  const { loading: isSellerNameLoading } = useTaxIdLookup(
+    sellerTaxId ?? "",
+    handleSellerNameLookup,
+  );
+  const { loading: isBuyerNameLoading } = useTaxIdLookup(
+    buyerTaxId ?? "",
+    handleBuyerNameLookup,
+  );
 
   const dateValue = form.watch("date");
   const selectedAllowanceDate = useMemo(
@@ -878,7 +910,12 @@ export function AllowanceReviewDialog({
                   name="sellerName"
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>賣方名稱</FormLabel>
+                      <FormLabel className="flex items-center gap-1">
+                        賣方名稱
+                        {isSellerNameLoading && (
+                          <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
+                        )}
+                      </FormLabel>
                       <FormControl>
                         <Input
                           {...field}
@@ -927,7 +964,12 @@ export function AllowanceReviewDialog({
                   name="buyerName"
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>買方名稱</FormLabel>
+                      <FormLabel className="flex items-center gap-1">
+                        買方名稱
+                        {isBuyerNameLoading && (
+                          <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
+                        )}
+                      </FormLabel>
                       <FormControl>
                         <Input
                           {...field}

--- a/components/allowance-review-dialog.tsx
+++ b/components/allowance-review-dialog.tsx
@@ -39,7 +39,7 @@ import {
   CalendarIcon,
 } from "lucide-react";
 import { type Allowance } from "@/lib/domain/models";
-import { useTaxIdLookup } from "@/hooks/use-tax-id-lookup";
+import { useFormTaxIdLookup } from "@/hooks/use-tax-id-lookup";
 import { updateAllowance } from "@/lib/services/allowance";
 import { toast } from "sonner";
 import { useState, useEffect, useCallback, useMemo } from "react";
@@ -191,33 +191,8 @@ export function AllowanceReviewDialog({
   const sellerTaxId = form.watch("sellerTaxId");
   const buyerTaxId = form.watch("buyerTaxId");
 
-  // Auto-lookup business names from FIA registry when tax IDs are present
-  const handleSellerNameLookup = useCallback(
-    (name: string) => {
-      form.setValue("sellerName", name);
-      const conf = form.getValues("confidence");
-      if (conf) form.setValue("confidence.sellerName", "high");
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [],
-  );
-  const handleBuyerNameLookup = useCallback(
-    (name: string) => {
-      form.setValue("buyerName", name);
-      const conf = form.getValues("confidence");
-      if (conf) form.setValue("confidence.buyerName", "high");
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [],
-  );
-  const { loading: isSellerNameLoading } = useTaxIdLookup(
-    sellerTaxId ?? "",
-    handleSellerNameLookup,
-  );
-  const { loading: isBuyerNameLoading } = useTaxIdLookup(
-    buyerTaxId ?? "",
-    handleBuyerNameLookup,
-  );
+  const { sellerLoading: isSellerNameLoading, buyerLoading: isBuyerNameLoading } =
+    useFormTaxIdLookup(form, sellerTaxId ?? "", buyerTaxId ?? "");
 
   const dateValue = form.watch("date");
   const selectedAllowanceDate = useMemo(

--- a/components/invoice-helper-form.tsx
+++ b/components/invoice-helper-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useRef } from "react";
 import { Plus, Trash2, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -9,6 +9,7 @@ import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
 import { labelText } from "@/lib/styles/tools";
+import { useTaxIdLookup } from "@/hooks/use-tax-id-lookup";
 import type {
   InvoiceFormData,
   InvoiceVariant,
@@ -19,35 +20,6 @@ import { createEmptyItem, computeTotals } from "./invoice-helper-client";
 
 // Shared class for enlarged inputs (buyer info, tax totals)
 const largeInputClass = "h-12 sm:h-10 text-lg";
-
-function useTaxIdLookup(
-  taxId: string,
-  onResult: (name: string) => void
-) {
-  const abortRef = useRef<AbortController | null>(null);
-  const lastLookedUp = useRef<string>("");
-
-  useEffect(() => {
-    if (taxId.length !== 8 || taxId === lastLookedUp.current) return;
-    lastLookedUp.current = taxId;
-
-    abortRef.current?.abort();
-    const controller = new AbortController();
-    abortRef.current = controller;
-
-    fetch(
-      `https://eip.fia.gov.tw/OAI/api/businessRegistration/${taxId}`,
-      { signal: controller.signal }
-    )
-      .then((res) => (res.ok ? res.json() : null))
-      .then((data) => {
-        if (data?.businessNm) onResult(data.businessNm);
-      })
-      .catch(() => {});
-
-    return () => controller.abort();
-  }, [taxId, onResult]);
-}
 
 interface InvoiceHelperFormProps {
   data: InvoiceFormData;
@@ -69,7 +41,7 @@ export function InvoiceHelperForm({ data, onChange }: InvoiceHelperFormProps) {
     cb({ ...d, buyerName: name });
   }, []);
 
-  useTaxIdLookup(data.buyerTaxId, handleLookupResult);
+  const { loading: isLookingUp } = useTaxIdLookup(data.buyerTaxId, handleLookupResult);
 
   function updateItem(index: number, patch: Partial<LineItem>) {
     const items = data.items.map((item, i) => {
@@ -144,7 +116,7 @@ export function InvoiceHelperForm({ data, onChange }: InvoiceHelperFormProps) {
             <div>
               <Label className="text-sm text-slate-600 mb-1 block flex items-center gap-1">
                 公司名稱
-                {data.buyerTaxId.length === 8 && !data.buyerName && (
+                {isLookingUp && (
                   <Loader2 className="h-3 w-3 animate-spin text-slate-400" />
                 )}
               </Label>

--- a/components/invoice-review-dialog.tsx
+++ b/components/invoice-review-dialog.tsx
@@ -48,7 +48,7 @@ import {
 } from "@/lib/domain/models";
 import { ACCOUNTS, ACCOUNT_LIST } from "@/lib/data/accounts";
 import { isValidUBN } from "@/lib/domain/tax-id";
-import { useTaxIdLookup } from "@/hooks/use-tax-id-lookup";
+import { useFormTaxIdLookup } from "@/hooks/use-tax-id-lookup";
 import { RocPeriod } from "@/lib/domain/roc-period";
 import { updateInvoice } from "@/lib/services/invoice";
 import { toast } from "sonner";
@@ -261,33 +261,8 @@ export function InvoiceReviewDialog({
     return !isValidUBN(buyerTaxId);
   }, [buyerTaxId]);
 
-  // Auto-lookup business names from FIA registry when tax IDs are present
-  const handleSellerNameLookup = useCallback(
-    (name: string) => {
-      form.setValue("sellerName", name);
-      const conf = form.getValues("confidence");
-      if (conf) form.setValue("confidence.sellerName", "high");
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [],
-  );
-  const handleBuyerNameLookup = useCallback(
-    (name: string) => {
-      form.setValue("buyerName", name);
-      const conf = form.getValues("confidence");
-      if (conf) form.setValue("confidence.buyerName", "high");
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [],
-  );
-  const { loading: isSellerNameLoading } = useTaxIdLookup(
-    sellerTaxId,
-    handleSellerNameLookup,
-  );
-  const { loading: isBuyerNameLoading } = useTaxIdLookup(
-    buyerTaxId ?? "",
-    handleBuyerNameLookup,
-  );
+  const { sellerLoading: isSellerNameLoading, buyerLoading: isBuyerNameLoading } =
+    useFormTaxIdLookup(form, sellerTaxId, buyerTaxId ?? "");
 
   const dateValue = form.watch("date");
   const inOrOutValue = form.watch("inOrOut");

--- a/components/invoice-review-dialog.tsx
+++ b/components/invoice-review-dialog.tsx
@@ -48,6 +48,7 @@ import {
 } from "@/lib/domain/models";
 import { ACCOUNTS, ACCOUNT_LIST } from "@/lib/data/accounts";
 import { isValidUBN } from "@/lib/domain/tax-id";
+import { useTaxIdLookup } from "@/hooks/use-tax-id-lookup";
 import { RocPeriod } from "@/lib/domain/roc-period";
 import { updateInvoice } from "@/lib/services/invoice";
 import { toast } from "sonner";
@@ -259,6 +260,34 @@ export function InvoiceReviewDialog({
     if (!buyerTaxId || buyerTaxId.length !== 8) return false;
     return !isValidUBN(buyerTaxId);
   }, [buyerTaxId]);
+
+  // Auto-lookup business names from FIA registry when tax IDs are present
+  const handleSellerNameLookup = useCallback(
+    (name: string) => {
+      form.setValue("sellerName", name);
+      const conf = form.getValues("confidence");
+      if (conf) form.setValue("confidence.sellerName", "high");
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+  const handleBuyerNameLookup = useCallback(
+    (name: string) => {
+      form.setValue("buyerName", name);
+      const conf = form.getValues("confidence");
+      if (conf) form.setValue("confidence.buyerName", "high");
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+  const { loading: isSellerNameLoading } = useTaxIdLookup(
+    sellerTaxId,
+    handleSellerNameLookup,
+  );
+  const { loading: isBuyerNameLoading } = useTaxIdLookup(
+    buyerTaxId ?? "",
+    handleBuyerNameLookup,
+  );
 
   const dateValue = form.watch("date");
   const inOrOutValue = form.watch("inOrOut");
@@ -1133,7 +1162,12 @@ export function InvoiceReviewDialog({
                   name="sellerName"
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>賣方名稱</FormLabel>
+                      <FormLabel className="flex items-center gap-1">
+                        賣方名稱
+                        {isSellerNameLoading && (
+                          <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
+                        )}
+                      </FormLabel>
                       <FormControl>
                         <Input
                           {...field}
@@ -1192,7 +1226,12 @@ export function InvoiceReviewDialog({
                   name="buyerName"
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>買方名稱</FormLabel>
+                      <FormLabel className="flex items-center gap-1">
+                        買方名稱
+                        {isBuyerNameLoading && (
+                          <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
+                        )}
+                      </FormLabel>
                       <FormControl>
                         <Input
                           {...field}

--- a/hooks/use-tax-id-lookup.ts
+++ b/hooks/use-tax-id-lookup.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * React hook that looks up a business name from Taiwan's FIA registry
+ * when a valid 8-digit tax ID (統一編號) is provided.
+ *
+ * Best-effort only — silently ignores failures.
+ */
+export function useTaxIdLookup(
+  taxId: string,
+  onResult: (name: string) => void,
+): { loading: boolean } {
+  const abortRef = useRef<AbortController | null>(null);
+  const lastLookedUp = useRef<string>("");
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (taxId.length !== 8 || taxId === lastLookedUp.current) return;
+    lastLookedUp.current = taxId;
+
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setLoading(true);
+
+    fetch(
+      `https://eip.fia.gov.tw/OAI/api/businessRegistration/${taxId}`,
+      { signal: controller.signal },
+    )
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (data?.businessNm) onResult(data.businessNm);
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+
+    return () => controller.abort();
+  }, [taxId, onResult]);
+
+  return { loading };
+}

--- a/hooks/use-tax-id-lookup.ts
+++ b/hooks/use-tax-id-lookup.ts
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { type UseFormReturn } from "react-hook-form";
 
 /**
  * React hook that looks up a business name from Taiwan's FIA registry
@@ -43,4 +44,39 @@ export function useTaxIdLookup(
   }, [taxId, onResult]);
 
   return { loading };
+}
+
+/**
+ * Convenience hook that wires useTaxIdLookup into a react-hook-form instance.
+ * Looks up both seller and buyer names, skipping no-op updates.
+ */
+export function useFormTaxIdLookup(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  form: UseFormReturn<any>,
+  sellerTaxId: string,
+  buyerTaxId: string,
+): { sellerLoading: boolean; buyerLoading: boolean } {
+  const formRef = useRef(form);
+  formRef.current = form;
+
+  const handleSellerName = useCallback((name: string) => {
+    const f = formRef.current;
+    if (f.getValues("sellerName") === name) return;
+    f.setValue("sellerName", name);
+    const conf = f.getValues("confidence");
+    if (conf) f.setValue("confidence.sellerName", "high");
+  }, []);
+
+  const handleBuyerName = useCallback((name: string) => {
+    const f = formRef.current;
+    if (f.getValues("buyerName") === name) return;
+    f.setValue("buyerName", name);
+    const conf = f.getValues("confidence");
+    if (conf) f.setValue("confidence.buyerName", "high");
+  }, []);
+
+  const { loading: sellerLoading } = useTaxIdLookup(sellerTaxId, handleSellerName);
+  const { loading: buyerLoading } = useTaxIdLookup(buyerTaxId, handleBuyerName);
+
+  return { sellerLoading, buyerLoading };
 }

--- a/hooks/use-tax-id-lookup.ts
+++ b/hooks/use-tax-id-lookup.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { type UseFormReturn } from "react-hook-form";
+import { lookupBusinessName } from "@/lib/services/business-lookup";
 
 /**
  * React hook that looks up a business name from Taiwan's FIA registry
@@ -27,15 +28,10 @@ export function useTaxIdLookup(
 
     setLoading(true);
 
-    fetch(
-      `https://eip.fia.gov.tw/OAI/api/businessRegistration/${taxId}`,
-      { signal: controller.signal },
-    )
-      .then((res) => (res.ok ? res.json() : null))
-      .then((data) => {
-        if (data?.businessNm) onResult(data.businessNm);
+    lookupBusinessName(taxId, controller.signal)
+      .then((name) => {
+        if (name) onResult(name);
       })
-      .catch(() => {})
       .finally(() => {
         if (!controller.signal.aborted) setLoading(false);
       });

--- a/lib/services/allowance.ts
+++ b/lib/services/allowance.ts
@@ -13,6 +13,7 @@ import { type Json, type TablesUpdate } from "@/supabase/database.types";
 import { tryLinkOriginalInvoice } from "@/lib/services/invoice-import";
 import { extractAllowanceData, type ClientInfo } from "@/lib/services/gemini";
 import { getImportFileMimeType } from "@/lib/utils/mime-type";
+import { enrichBusinessNames } from "@/lib/services/business-lookup";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { ensurePeriodEditable } from "@/lib/services/tax-period";
 
@@ -193,12 +194,28 @@ export async function extractAllowanceCore(
 
     const validatedData = extractedAllowanceDataSchema.parse(normalizedData);
 
+    // Enrich business names from FIA registry (best-effort)
+    const enrichedData = await enrichBusinessNames(validatedData, [
+      {
+        name: validatedData.sellerName,
+        taxId: validatedData.sellerTaxId,
+        nameField: "sellerName",
+        taxIdField: "sellerTaxId",
+      },
+      {
+        name: validatedData.buyerName,
+        taxId: validatedData.buyerTaxId,
+        nameField: "buyerName",
+        taxIdField: "buyerTaxId",
+      },
+    ]);
+
     const clientTaxId = client?.tax_id || "";
     let derivedInOrOut: "in" | "out" | undefined;
     if (clientTaxId) {
-      if (validatedData.sellerTaxId === clientTaxId) {
+      if (enrichedData.sellerTaxId === clientTaxId) {
         derivedInOrOut = "out";
-      } else if (validatedData.buyerTaxId === clientTaxId) {
+      } else if (enrichedData.buyerTaxId === clientTaxId) {
         derivedInOrOut = "in";
       }
     }
@@ -206,10 +223,10 @@ export async function extractAllowanceCore(
     const fallbackInOrOut = allowance.in_or_out === "in" ? "in" : "out";
 
     return await updateAllowance(allowanceId, {
-      extracted_data: validatedData,
+      extracted_data: enrichedData,
       status: "processed",
       original_invoice_serial_code:
-        validatedData.originalInvoiceSerialCode || null,
+        enrichedData.originalInvoiceSerialCode || null,
       in_or_out: derivedInOrOut ?? fallbackInOrOut,
     });
   } catch (error) {

--- a/lib/services/allowance.ts
+++ b/lib/services/allowance.ts
@@ -194,7 +194,6 @@ export async function extractAllowanceCore(
 
     const validatedData = extractedAllowanceDataSchema.parse(normalizedData);
 
-    // Enrich business names from FIA registry (best-effort)
     const enrichedData = await enrichBusinessNames(validatedData, [
       {
         name: validatedData.sellerName,

--- a/lib/services/allowance.ts
+++ b/lib/services/allowance.ts
@@ -13,7 +13,7 @@ import { type Json, type TablesUpdate } from "@/supabase/database.types";
 import { tryLinkOriginalInvoice } from "@/lib/services/invoice-import";
 import { extractAllowanceData, type ClientInfo } from "@/lib/services/gemini";
 import { getImportFileMimeType } from "@/lib/utils/mime-type";
-import { enrichBusinessNames } from "@/lib/services/business-lookup";
+import { enrichExtractedParties } from "@/lib/services/business-lookup";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { ensurePeriodEditable } from "@/lib/services/tax-period";
 
@@ -194,20 +194,13 @@ export async function extractAllowanceCore(
 
     const validatedData = extractedAllowanceDataSchema.parse(normalizedData);
 
-    const enrichedData = await enrichBusinessNames(validatedData, [
-      {
-        name: validatedData.sellerName,
-        taxId: validatedData.sellerTaxId,
-        nameField: "sellerName",
-        taxIdField: "sellerTaxId",
-      },
-      {
-        name: validatedData.buyerName,
-        taxId: validatedData.buyerTaxId,
-        nameField: "buyerName",
-        taxIdField: "buyerTaxId",
-      },
-    ]);
+    // allowance.in_or_out is the upload-time hint; the authoritative value is
+    // derived below from tax-id matching once both parties are resolved.
+    const enrichedData = await enrichExtractedParties(
+      validatedData,
+      allowance.in_or_out === "in" ? "in" : "out",
+      client?.tax_id ? { name: client.name, taxId: client.tax_id } : null,
+    );
 
     const clientTaxId = client?.tax_id || "";
     let derivedInOrOut: "in" | "out" | undefined;

--- a/lib/services/business-lookup.ts
+++ b/lib/services/business-lookup.ts
@@ -1,0 +1,80 @@
+const FIA_API_BASE = "https://eip.fia.gov.tw/OAI/api/businessRegistration";
+
+/**
+ * Look up a business name from Taiwan's FIA registry by tax ID (統一編號).
+ * Best-effort only — returns null on any failure (network, invalid response, etc.).
+ */
+export async function lookupBusinessName(
+  taxId: string,
+): Promise<string | null> {
+  if (!/^\d{8}$/.test(taxId)) return null;
+
+  try {
+    const res = await fetch(`${FIA_API_BASE}/${taxId}`);
+    if (!res.ok) return null;
+    const data = await res.json();
+    return data?.businessNm || null;
+  } catch {
+    return null;
+  }
+}
+
+type ConfidenceLevel = "low" | "medium" | "high";
+
+interface ConfidenceMap {
+  [field: string]: ConfidenceLevel | undefined;
+}
+
+interface PartyFields {
+  name: string | undefined;
+  taxId: string | undefined;
+  nameField: string;
+  taxIdField: string;
+}
+
+/**
+ * Enrich extracted data with business names from FIA lookup.
+ * Skips lookup when:
+ * - taxId is missing or not 8 digits
+ * - taxId confidence is "low" (likely a bad OCR read)
+ * - name already has "high" confidence
+ */
+export async function enrichBusinessNames<
+  T extends { confidence?: ConfidenceMap },
+>(
+  data: T,
+  parties: PartyFields[],
+): Promise<T> {
+  const enriched = { ...data };
+  const confidence: ConfidenceMap = { ...data.confidence };
+
+  const lookups = parties.map(async (party) => {
+    const taxId = party.taxId;
+    if (!taxId || !/^\d{8}$/.test(taxId)) return;
+
+    // Skip if the tax ID itself has low confidence
+    const taxIdConfidence = confidence[party.taxIdField];
+    if (taxIdConfidence === "low") return;
+
+    // Skip if name already has high confidence
+    const nameConfidence = confidence[party.nameField];
+    if (nameConfidence === "high") return;
+
+    // Skip if name is present and has no confidence data (e.g. from excel import)
+    if (party.name && !data.confidence) return;
+
+    const name = await lookupBusinessName(taxId);
+    if (name) {
+      (enriched as Record<string, unknown>)[party.nameField] = name;
+      confidence[party.nameField] = "high";
+    }
+  });
+
+  await Promise.all(lookups);
+
+  if (data.confidence) {
+    (enriched as Record<string, unknown>).confidence = confidence;
+  }
+
+  return enriched;
+}

--- a/lib/services/business-lookup.ts
+++ b/lib/services/business-lookup.ts
@@ -3,14 +3,16 @@ const FIA_API_BASE = "https://eip.fia.gov.tw/OAI/api/businessRegistration";
 /**
  * Look up a business name from Taiwan's FIA registry by tax ID (統一編號).
  * Best-effort only — returns null on any failure (network, invalid response, etc.).
+ * Pass an AbortSignal to allow callers (e.g. React effects) to cancel in-flight requests.
  */
 export async function lookupBusinessName(
   taxId: string,
+  signal?: AbortSignal,
 ): Promise<string | null> {
   if (!/^\d{8}$/.test(taxId)) return null;
 
   try {
-    const res = await fetch(`${FIA_API_BASE}/${taxId}`);
+    const res = await fetch(`${FIA_API_BASE}/${taxId}`, { signal });
     if (!res.ok) return null;
     const data = await res.json();
     return data?.businessNm || null;
@@ -30,6 +32,69 @@ interface PartyFields {
   taxId: string | undefined;
   nameField: string;
   taxIdField: string;
+}
+
+/**
+ * Overwrite one party's fields with the canonical client record.
+ * Trust the firm's record over Gemini's OCR for whichever side is the client.
+ */
+function applyKnownClient<T extends { confidence?: ConfidenceMap }>(
+  data: T,
+  side: "buyer" | "seller",
+  client: { name: string; taxId: string },
+): T {
+  const nameField = `${side}Name`;
+  const taxIdField = `${side}TaxId`;
+  const result: Record<string, unknown> = { ...data };
+  result[nameField] = client.name;
+  result[taxIdField] = client.taxId;
+  if (data.confidence) {
+    result.confidence = {
+      ...data.confidence,
+      [nameField]: "high",
+      [taxIdField]: "high",
+    };
+  }
+  return result as T;
+}
+
+function partyOf<T>(data: T, side: "buyer" | "seller"): PartyFields {
+  const nameField = `${side}Name`;
+  const taxIdField = `${side}TaxId`;
+  const record = data as Record<string, unknown>;
+  return {
+    name: record[nameField] as string | undefined,
+    taxId: record[taxIdField] as string | undefined,
+    nameField,
+    taxIdField,
+  };
+}
+
+/**
+ * Apply the firm's canonical client record to whichever side it represents
+ * (buyer for 進項, seller for 銷項), then FIA-look-up the other party only.
+ * Falls back to enriching both sides when no client record is available.
+ */
+export async function enrichExtractedParties<
+  T extends { confidence?: ConfidenceMap },
+>(
+  data: T,
+  inOrOut: "in" | "out",
+  client: { name: string; taxId: string } | null,
+): Promise<T> {
+  if (!client?.taxId) {
+    return await enrichBusinessNames(data, [
+      partyOf(data, "seller"),
+      partyOf(data, "buyer"),
+    ]);
+  }
+
+  const clientSide = inOrOut === "in" ? "buyer" : "seller";
+  const otherSide = inOrOut === "in" ? "seller" : "buyer";
+  const dataWithClient = applyKnownClient(data, clientSide, client);
+  return await enrichBusinessNames(dataWithClient, [
+    partyOf(dataWithClient, otherSide),
+  ]);
 }
 
 /**

--- a/lib/services/invoice.ts
+++ b/lib/services/invoice.ts
@@ -19,6 +19,7 @@ import { type Json, type TablesUpdate } from "@/supabase/database.types";
 import { type ExtractedInvoiceData } from "@/lib/domain/models";
 import { ensurePeriodEditable } from "@/lib/services/tax-period";
 import { getImportFileMimeType } from "@/lib/utils/mime-type";
+import { enrichBusinessNames } from "@/lib/services/business-lookup";
 import type { SupabaseClient } from "@supabase/supabase-js";
 
 async function saveExtractedInvoiceData(
@@ -409,7 +410,23 @@ export async function extractInvoiceCore(
     // Validate extracted data against schema
     const validatedData = extractedInvoiceDataSchema.parse(extractedData);
 
-    return await saveExtractedInvoiceData(invoiceId, validatedData, supabase);
+    // Enrich business names from FIA registry (best-effort)
+    const enrichedData = await enrichBusinessNames(validatedData, [
+      {
+        name: validatedData.sellerName,
+        taxId: validatedData.sellerTaxId,
+        nameField: "sellerName",
+        taxIdField: "sellerTaxId",
+      },
+      {
+        name: validatedData.buyerName,
+        taxId: validatedData.buyerTaxId,
+        nameField: "buyerName",
+        taxIdField: "buyerTaxId",
+      },
+    ]);
+
+    return await saveExtractedInvoiceData(invoiceId, enrichedData, supabase);
   } catch (error) {
     // Update status to failed on error
     const errorMessage =

--- a/lib/services/invoice.ts
+++ b/lib/services/invoice.ts
@@ -410,7 +410,6 @@ export async function extractInvoiceCore(
     // Validate extracted data against schema
     const validatedData = extractedInvoiceDataSchema.parse(extractedData);
 
-    // Enrich business names from FIA registry (best-effort)
     const enrichedData = await enrichBusinessNames(validatedData, [
       {
         name: validatedData.sellerName,

--- a/lib/services/invoice.ts
+++ b/lib/services/invoice.ts
@@ -19,7 +19,7 @@ import { type Json, type TablesUpdate } from "@/supabase/database.types";
 import { type ExtractedInvoiceData } from "@/lib/domain/models";
 import { ensurePeriodEditable } from "@/lib/services/tax-period";
 import { getImportFileMimeType } from "@/lib/utils/mime-type";
-import { enrichBusinessNames } from "@/lib/services/business-lookup";
+import { enrichExtractedParties } from "@/lib/services/business-lookup";
 import type { SupabaseClient } from "@supabase/supabase-js";
 
 async function saveExtractedInvoiceData(
@@ -410,20 +410,11 @@ export async function extractInvoiceCore(
     // Validate extracted data against schema
     const validatedData = extractedInvoiceDataSchema.parse(extractedData);
 
-    const enrichedData = await enrichBusinessNames(validatedData, [
-      {
-        name: validatedData.sellerName,
-        taxId: validatedData.sellerTaxId,
-        nameField: "sellerName",
-        taxIdField: "sellerTaxId",
-      },
-      {
-        name: validatedData.buyerName,
-        taxId: validatedData.buyerTaxId,
-        nameField: "buyerName",
-        taxIdField: "buyerTaxId",
-      },
-    ]);
+    const enrichedData = await enrichExtractedParties(
+      validatedData,
+      invoice.in_or_out === "in" ? "in" : "out",
+      client?.tax_id ? { name: client.name, taxId: client.tax_id } : null,
+    );
 
     return await saveExtractedInvoiceData(invoiceId, enrichedData, supabase);
   } catch (error) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9831,6 +9831,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -11741,6 +11742,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11757,6 +11759,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11773,6 +11776,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11789,6 +11793,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11805,6 +11810,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11821,6 +11827,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11837,6 +11844,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11853,6 +11861,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11869,6 +11878,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11885,6 +11895,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11901,6 +11912,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11917,6 +11929,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11933,6 +11946,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11949,6 +11963,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11965,6 +11980,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11981,6 +11997,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11997,6 +12014,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12013,6 +12031,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12029,6 +12048,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12045,6 +12065,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12061,6 +12082,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12077,6 +12099,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12093,6 +12116,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12109,6 +12133,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12125,6 +12150,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12141,6 +12167,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/supabase/functions/extraction-worker/index.ts
+++ b/supabase/functions/extraction-worker/index.ts
@@ -89,6 +89,60 @@ interface GeminiResponse {
   }>;
 }
 
+// ─── FIA business name lookup (best-effort) ────────────────────────────────
+
+const FIA_API_BASE = "https://eip.fia.gov.tw/OAI/api/businessRegistration";
+
+async function lookupBusinessName(taxId: string): Promise<string | null> {
+  if (!/^\d{8}$/.test(taxId)) return null;
+  try {
+    const res = await fetch(`${FIA_API_BASE}/${taxId}`);
+    if (!res.ok) return null;
+    const data = await res.json();
+    return data?.businessNm || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Enrich extracted data with business names from FIA registry.
+ * Skips lookup when taxId is missing/invalid, taxId confidence is "low",
+ * or name confidence is already "high".
+ */
+async function enrichBusinessNames(
+  data: Record<string, unknown>,
+  parties: Array<{ nameField: string; taxIdField: string }>,
+): Promise<void> {
+  const confidence = (data.confidence ?? {}) as Record<string, string | undefined>;
+
+  const lookups = parties.map(async (party) => {
+    const taxId = data[party.taxIdField] as string | undefined;
+    if (!taxId || !/^\d{8}$/.test(taxId)) return;
+
+    const taxIdConf = confidence[party.taxIdField];
+    if (taxIdConf === "low") return;
+
+    const nameConf = confidence[party.nameField];
+    if (nameConf === "high") return;
+
+    const currentName = data[party.nameField] as string | undefined;
+    if (currentName && !data.confidence) return;
+
+    const name = await lookupBusinessName(taxId);
+    if (name) {
+      data[party.nameField] = name;
+      confidence[party.nameField] = "high";
+    }
+  });
+
+  await Promise.all(lookups);
+
+  if (data.confidence) {
+    data.confidence = confidence;
+  }
+}
+
 // ─── Gemini API helpers ─────────────────────────────────────────────────────
 
 function getGeminiApiUrl(): string {
@@ -229,6 +283,12 @@ async function extractInvoice(
     extractedData.account = extractedData.account
       .replace(/－/g, "-").replace(/：/g, ":");
   }
+
+  // Enrich business names from FIA registry (best-effort)
+  await enrichBusinessNames(extractedData, [
+    { nameField: "sellerName", taxIdField: "sellerTaxId" },
+    { nameField: "buyerName", taxIdField: "buyerTaxId" },
+  ]);
 
   await saveInvoiceResult(supabase, invoiceId, extractedData);
 }
@@ -431,6 +491,12 @@ async function extractAllowance(
 
   // Add source
   extractedData.source = "scan";
+
+  // Enrich business names from FIA registry (best-effort)
+  await enrichBusinessNames(extractedData, [
+    { nameField: "sellerName", taxIdField: "sellerTaxId" },
+    { nameField: "buyerName", taxIdField: "buyerTaxId" },
+  ]);
 
   // Derive in_or_out from tax IDs
   let derivedInOrOut: string | undefined;

--- a/supabase/functions/extraction-worker/index.ts
+++ b/supabase/functions/extraction-worker/index.ts
@@ -93,14 +93,23 @@ interface GeminiResponse {
 
 const FIA_API_BASE = "https://eip.fia.gov.tw/OAI/api/businessRegistration";
 
+// Batch-level cache — avoids redundant FIA lookups for the same tax ID
+// within a single invocation (common: multiple invoices from the same seller).
+// Cleared on each new Serve() invocation.
+let businessNameCache = new Map<string, string | null>();
+
 async function lookupBusinessName(taxId: string): Promise<string | null> {
   if (!/^\d{8}$/.test(taxId)) return null;
+  if (businessNameCache.has(taxId)) return businessNameCache.get(taxId)!;
   try {
     const res = await fetch(`${FIA_API_BASE}/${taxId}`);
-    if (!res.ok) return null;
+    if (!res.ok) { businessNameCache.set(taxId, null); return null; }
     const data = await res.json();
-    return data?.businessNm || null;
+    const name = data?.businessNm || null;
+    businessNameCache.set(taxId, name);
+    return name;
   } catch {
+    businessNameCache.set(taxId, null);
     return null;
   }
 }
@@ -284,7 +293,6 @@ async function extractInvoice(
       .replace(/－/g, "-").replace(/：/g, ":");
   }
 
-  // Enrich business names from FIA registry (best-effort)
   await enrichBusinessNames(extractedData, [
     { nameField: "sellerName", taxIdField: "sellerTaxId" },
     { nameField: "buyerName", taxIdField: "buyerTaxId" },
@@ -492,7 +500,6 @@ async function extractAllowance(
   // Add source
   extractedData.source = "scan";
 
-  // Enrich business names from FIA registry (best-effort)
   await enrichBusinessNames(extractedData, [
     { nameField: "sellerName", taxIdField: "sellerTaxId" },
     { nameField: "buyerName", taxIdField: "buyerTaxId" },
@@ -621,6 +628,7 @@ async function processOneMessage(
 }
 
 Deno.serve(async (req) => {
+  businessNameCache = new Map();
   const invocationStart = Date.now();
   try {
     // Verify authorization

--- a/supabase/functions/extraction-worker/index.ts
+++ b/supabase/functions/extraction-worker/index.ts
@@ -93,63 +93,82 @@ interface GeminiResponse {
 
 const FIA_API_BASE = "https://eip.fia.gov.tw/OAI/api/businessRegistration";
 
-// Batch-level cache — avoids redundant FIA lookups for the same tax ID
-// within a single invocation (common: multiple invoices from the same seller).
-// Cleared on each new Serve() invocation.
-let businessNameCache = new Map<string, string | null>();
-
 async function lookupBusinessName(taxId: string): Promise<string | null> {
   if (!/^\d{8}$/.test(taxId)) return null;
-  if (businessNameCache.has(taxId)) return businessNameCache.get(taxId)!;
   try {
     const res = await fetch(`${FIA_API_BASE}/${taxId}`);
-    if (!res.ok) { businessNameCache.set(taxId, null); return null; }
+    if (!res.ok) return null;
     const data = await res.json();
-    const name = data?.businessNm || null;
-    businessNameCache.set(taxId, name);
-    return name;
+    return data?.businessNm || null;
   } catch {
-    businessNameCache.set(taxId, null);
     return null;
   }
 }
 
+function applyKnownClient(
+  data: Record<string, unknown>,
+  side: "buyer" | "seller",
+  client: { name: string; taxId: string },
+): void {
+  const nameField = `${side}Name`;
+  const taxIdField = `${side}TaxId`;
+  data[nameField] = client.name;
+  data[taxIdField] = client.taxId;
+  if (data.confidence) {
+    const confidence = data.confidence as Record<string, string>;
+    confidence[nameField] = "high";
+    confidence[taxIdField] = "high";
+  }
+}
+
 /**
- * Enrich extracted data with business names from FIA registry.
- * Skips lookup when taxId is missing/invalid, taxId confidence is "low",
+ * Look up FIA business name for one party and write it back into `data`.
+ * Skips when taxId is missing/invalid, taxId confidence is "low",
  * or name confidence is already "high".
  */
-async function enrichBusinessNames(
+async function enrichParty(
   data: Record<string, unknown>,
-  parties: Array<{ nameField: string; taxIdField: string }>,
+  side: "buyer" | "seller",
 ): Promise<void> {
+  const nameField = `${side}Name`;
+  const taxIdField = `${side}TaxId`;
+  const taxId = data[taxIdField] as string | undefined;
+  if (!taxId || !/^\d{8}$/.test(taxId)) return;
+
   const confidence = (data.confidence ?? {}) as Record<string, string | undefined>;
+  if (confidence[taxIdField] === "low") return;
+  if (confidence[nameField] === "high") return;
 
-  const lookups = parties.map(async (party) => {
-    const taxId = data[party.taxIdField] as string | undefined;
-    if (!taxId || !/^\d{8}$/.test(taxId)) return;
+  const currentName = data[nameField] as string | undefined;
+  if (currentName && !data.confidence) return;
 
-    const taxIdConf = confidence[party.taxIdField];
-    if (taxIdConf === "low") return;
-
-    const nameConf = confidence[party.nameField];
-    if (nameConf === "high") return;
-
-    const currentName = data[party.nameField] as string | undefined;
-    if (currentName && !data.confidence) return;
-
-    const name = await lookupBusinessName(taxId);
-    if (name) {
-      data[party.nameField] = name;
-      confidence[party.nameField] = "high";
+  const name = await lookupBusinessName(taxId);
+  if (name) {
+    data[nameField] = name;
+    if (data.confidence) {
+      confidence[nameField] = "high";
+      data.confidence = confidence;
     }
-  });
-
-  await Promise.all(lookups);
-
-  if (data.confidence) {
-    data.confidence = confidence;
   }
+}
+
+/**
+ * Apply the firm's canonical client record to whichever side it represents
+ * (buyer for 進項, seller for 銷項), then FIA-look-up the other party only.
+ * Falls back to enriching both sides when no client record is available.
+ */
+async function enrichExtractedParties(
+  data: Record<string, unknown>,
+  inOrOut: "in" | "out",
+  client: { name: string; taxId: string } | null,
+): Promise<void> {
+  if (!client?.taxId) {
+    await Promise.all([enrichParty(data, "seller"), enrichParty(data, "buyer")]);
+    return;
+  }
+  const clientSide = inOrOut === "in" ? "buyer" : "seller";
+  applyKnownClient(data, clientSide, client);
+  await enrichParty(data, clientSide === "buyer" ? "seller" : "buyer");
 }
 
 // ─── Gemini API helpers ─────────────────────────────────────────────────────
@@ -293,10 +312,11 @@ async function extractInvoice(
       .replace(/－/g, "-").replace(/：/g, ":");
   }
 
-  await enrichBusinessNames(extractedData, [
-    { nameField: "sellerName", taxIdField: "sellerTaxId" },
-    { nameField: "buyerName", taxIdField: "buyerTaxId" },
-  ]);
+  await enrichExtractedParties(
+    extractedData,
+    invoice.in_or_out === "in" ? "in" : "out",
+    clientInfo.taxId ? { name: clientInfo.name, taxId: clientInfo.taxId } : null,
+  );
 
   await saveInvoiceResult(supabase, invoiceId, extractedData);
 }
@@ -500,10 +520,13 @@ async function extractAllowance(
   // Add source
   extractedData.source = "scan";
 
-  await enrichBusinessNames(extractedData, [
-    { nameField: "sellerName", taxIdField: "sellerTaxId" },
-    { nameField: "buyerName", taxIdField: "buyerTaxId" },
-  ]);
+  // allowance.in_or_out is the upload-time hint; the authoritative value is
+  // derived below from tax-id matching once both parties are resolved.
+  await enrichExtractedParties(
+    extractedData,
+    allowance.in_or_out === "in" ? "in" : "out",
+    clientTaxId ? { name: clientInfo.name, taxId: clientTaxId } : null,
+  );
 
   // Derive in_or_out from tax IDs
   let derivedInOrOut: string | undefined;
@@ -628,7 +651,6 @@ async function processOneMessage(
 }
 
 Deno.serve(async (req) => {
-  businessNameCache = new Map();
   const invocationStart = Date.now();
   try {
     // Verify authorization


### PR DESCRIPTION
Extract the tax ID → business name lookup (via Taiwan FIA API) from
invoice-helper-form into shared utilities and integrate it in:

- Server-side: enrich extracted data with verified business names after
  Gemini AI extraction in invoice.ts, allowance.ts, and the extraction
  worker edge function. Skips lookup when tax ID confidence is low.
- Client-side: auto-populate business names in invoice and allowance
  review dialogs when a valid tax ID is present or edited by the reviewer.

This reduces the number of fields requiring human review by resolving
business names from the government registry automatically.

https://claude.ai/code/session_01PwFX38mBm2NHGffGyN3YB9