### PR TITLE
fix: add explicit favicon icon reference for Chrome

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -24,6 +24,7 @@ export const metadata: Metadata = {
     "SnapBooks.ai 協助一人公司與小型團隊，拍照上傳單據與 AI 整理流程，更快完成記帳與報稅。",
   manifest: "/manifest.json",
   icons: {
+    icon: [{ url: "/icon.svg", type: "image/svg+xml" }],
     apple: "/apple-touch-icon.png",
   },
   appleWebApp: {


### PR DESCRIPTION
## Summary
- Added explicit `icon` entry to the `icons` metadata in `app/layout.tsx`
- The existing `app/icon.svg` was not being referenced in the HTML head because the `icons` config only specified `apple`, causing Chrome to miss the favicon

## Test plan
- [ ] Open the app in Chrome and verify the favicon appears in the browser tab
- [ ] Verify the favicon also appears in other browsers (Safari, Firefox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)