### PR TITLE
feat: add confirmation dialog before revoking portal access

### DIFF
--- a/app/firm/[firmId]/client/[clientId]/page.tsx
+++ b/app/firm/[firmId]/client/[clientId]/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { use } from "react";
+import { use, useState } from "react";
 import useSWR from "swr";
 import { createClient as createSupabaseClient } from "@/lib/supabase/client";
-import { Button, buttonVariants } from "@/components/ui/button";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Loader2, ArrowLeft, ShieldCheck } from "lucide-react";
@@ -67,14 +67,21 @@ export default function ClientDetailPage({
     mutate: fetchPortalUsers,
   } = useSWR(["client-portal-users", clientId], () => getClientUsers(clientId));
 
+  const [isRevoking, setIsRevoking] = useState(false);
+  const [revokeDialogOpen, setRevokeDialogOpen] = useState(false);
+
   const handleRevokeAccess = async (userId: string) => {
+    setIsRevoking(true);
     try {
       await revokeClientUserAccess(userId);
       toast.success("已撤銷入口網站帳號");
+      setRevokeDialogOpen(false);
       fetchPortalUsers();
     } catch (error) {
       console.error(error);
       toast.error(error instanceof Error ? error.message : "撤銷失敗");
+    } finally {
+      setIsRevoking(false);
     }
   };
 
@@ -207,7 +214,10 @@ export default function ClientDetailPage({
                           </p>
                           <Badge variant="secondary">啟用中</Badge>
                         </div>
-                        <AlertDialog>
+                        <AlertDialog
+                          open={revokeDialogOpen}
+                          onOpenChange={setRevokeDialogOpen}
+                        >
                           <AlertDialogTrigger asChild>
                             <Button variant="outline">撤銷存取</Button>
                           </AlertDialogTrigger>
@@ -222,12 +232,22 @@ export default function ClientDetailPage({
                               </AlertDialogDescription>
                             </AlertDialogHeader>
                             <AlertDialogFooter>
-                              <AlertDialogCancel>取消</AlertDialogCancel>
+                              <AlertDialogCancel disabled={isRevoking}>
+                                取消
+                              </AlertDialogCancel>
                               <AlertDialogAction
-                                className={buttonVariants({ variant: "destructive" })}
-                                onClick={() => handleRevokeAccess(user.id)}
+                                asChild
+                                onClick={(e) => {
+                                  e.preventDefault();
+                                  handleRevokeAccess(user.id);
+                                }}
                               >
-                                確定撤銷
+                                <Button variant="destructive" disabled={isRevoking}>
+                                  {isRevoking && (
+                                    <Loader2 className="h-4 w-4 animate-spin" />
+                                  )}
+                                  確定撤銷
+                                </Button>
                               </AlertDialogAction>
                             </AlertDialogFooter>
                           </AlertDialogContent>

--- a/app/firm/[firmId]/client/[clientId]/page.tsx
+++ b/app/firm/[firmId]/client/[clientId]/page.tsx
@@ -3,7 +3,7 @@
 import { use } from "react";
 import useSWR from "swr";
 import { createClient as createSupabaseClient } from "@/lib/supabase/client";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Loader2, ArrowLeft, ShieldCheck } from "lucide-react";
@@ -18,6 +18,17 @@ import {
 } from "@/lib/services/client-user";
 import { InviteClientDialog } from "@/components/invite-client-dialog";
 import { Badge } from "@/components/ui/badge";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import { toast } from "sonner";
 
 export default function ClientDetailPage({
@@ -196,12 +207,31 @@ export default function ClientDetailPage({
                           </p>
                           <Badge variant="secondary">啟用中</Badge>
                         </div>
-                        <Button
-                          variant="outline"
-                          onClick={() => handleRevokeAccess(user.id)}
-                        >
-                          撤銷存取
-                        </Button>
+                        <AlertDialog>
+                          <AlertDialogTrigger asChild>
+                            <Button variant="outline">撤銷存取</Button>
+                          </AlertDialogTrigger>
+                          <AlertDialogContent>
+                            <AlertDialogHeader>
+                              <AlertDialogTitle>
+                                確定要撤銷此帳號的存取權限?
+                              </AlertDialogTitle>
+                              <AlertDialogDescription>
+                                撤銷後，{user.name || user.email || "此使用者"}
+                                將無法再登入入口網站。此操作無法復原。
+                              </AlertDialogDescription>
+                            </AlertDialogHeader>
+                            <AlertDialogFooter>
+                              <AlertDialogCancel>取消</AlertDialogCancel>
+                              <AlertDialogAction
+                                className={buttonVariants({ variant: "destructive" })}
+                                onClick={() => handleRevokeAccess(user.id)}
+                              >
+                                確定撤銷
+                              </AlertDialogAction>
+                            </AlertDialogFooter>
+                          </AlertDialogContent>
+                        </AlertDialog>
                       </div>
                     ))}
                   </div>

--- a/app/firm/[firmId]/client/[clientId]/page.tsx
+++ b/app/firm/[firmId]/client/[clientId]/page.tsx
@@ -236,18 +236,17 @@ export default function ClientDetailPage({
                                 取消
                               </AlertDialogCancel>
                               <AlertDialogAction
-                                asChild
+                                className="bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90"
+                                disabled={isRevoking}
                                 onClick={(e) => {
                                   e.preventDefault();
                                   handleRevokeAccess(user.id);
                                 }}
                               >
-                                <Button variant="destructive" disabled={isRevoking}>
-                                  {isRevoking && (
-                                    <Loader2 className="h-4 w-4 animate-spin" />
-                                  )}
-                                  確定撤銷
-                                </Button>
+                                {isRevoking && (
+                                  <Loader2 className="h-4 w-4 animate-spin" />
+                                )}
+                                確定撤銷
                               </AlertDialogAction>
                             </AlertDialogFooter>
                           </AlertDialogContent>

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -1,0 +1,141 @@
+"use client"
+
+import * as React from "react"
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+
+const AlertDialog = AlertDialogPrimitive.Root
+
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger
+
+const AlertDialogPortal = AlertDialogPrimitive.Portal
+
+const AlertDialogOverlay = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+))
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName
+
+const AlertDialogContent = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPortal>
+    <AlertDialogOverlay />
+    <AlertDialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className
+      )}
+      {...props}
+    />
+  </AlertDialogPortal>
+))
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName
+
+const AlertDialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+AlertDialogHeader.displayName = "AlertDialogHeader"
+
+const AlertDialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+AlertDialogFooter.displayName = "AlertDialogFooter"
+
+const AlertDialogTitle = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold", className)}
+    {...props}
+  />
+))
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName
+
+const AlertDialogDescription = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+AlertDialogDescription.displayName =
+  AlertDialogPrimitive.Description.displayName
+
+const AlertDialogAction = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Action>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Action
+    ref={ref}
+    className={cn(buttonVariants(), className)}
+    {...props}
+  />
+))
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName
+
+const AlertDialogCancel = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Cancel
+    ref={ref}
+    className={cn(
+      buttonVariants({ variant: "outline" }),
+      "mt-2 sm:mt-0",
+      className
+    )}
+    {...props}
+  />
+))
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@next/mdx": "^16.2.1",
         "@next/third-parties": "^16.2.0",
         "@radix-ui/react-accordion": "^1.2.12",
+        "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.1",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.14",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@next/mdx": "^16.2.1",
     "@next/third-parties": "^16.2.0",
     "@radix-ui/react-accordion": "^1.2.12",
+    "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.1",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.14",


### PR DESCRIPTION
## Summary
- Add an AlertDialog confirmation step before revoking a client portal user's access
- Uses destructive button variant for clear visual warning
- Dialog shows the user's name/email and warns the action is irreversible

## Test plan
- [ ] Navigate to a client detail page > 基本資料 tab > 入口網站存取 section
- [ ] Click "撤銷存取" — verify the confirmation dialog appears
- [ ] Click "取消" — verify the dialog closes without revoking
- [ ] Click "確定撤銷" — verify the revoke action proceeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)