### PR TITLE
fix: increase text sizes across app for readability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,13 @@ Currently public:
 - Exact paths in `publicRoutes`: `/`, `/terms`, `/privacy`, `/company`, `/blog`
 - Prefix matches: `/auth`, `/login`, `/blog/`
 
+### Text Sizing Convention
+
+- **`text-base`** (16px) — default for all body text, labels, descriptions, form fields, table content, navigation items
+- **`text-sm`** (14px) — secondary/supplementary text only: captions, hints, metadata, muted helper text
+- **Never use `text-xs`** (12px) in app-owned components. The minimum readable size is `text-sm`
+- shadcn/ui primitives (`components/ui/`) keep their upstream defaults — override sizes at the usage site if needed
+
 ### Supabase
 
 - `supabase/database.types.ts` — Auto-generated TypeScript types from schema

--- a/app/firm/[firmId]/client/[clientId]/page.tsx
+++ b/app/firm/[firmId]/client/[clientId]/page.tsx
@@ -153,25 +153,25 @@ export default function ClientDetailPage({
               </CardHeader>
               <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div>
-                  <p className="text-sm font-medium text-muted-foreground">
+                  <p className="text-base font-medium text-muted-foreground">
                     統一編號
                   </p>
                   <p>{client.tax_id}</p>
                 </div>
                 <div>
-                  <p className="text-sm font-medium text-muted-foreground">
+                  <p className="text-base font-medium text-muted-foreground">
                     稅籍編號
                   </p>
                   <p>{client.tax_payer_id}</p>
                 </div>
                 <div>
-                  <p className="text-sm font-medium text-muted-foreground">
+                  <p className="text-base font-medium text-muted-foreground">
                     負責人
                   </p>
                   <p>{client.contact_person || "-"}</p>
                 </div>
                 <div>
-                  <p className="text-sm font-medium text-muted-foreground">
+                  <p className="text-base font-medium text-muted-foreground">
                     產業
                   </p>
                   <p>{client.industry || "-"}</p>
@@ -197,7 +197,7 @@ export default function ClientDetailPage({
                     <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
                   </div>
                 ) : portalUsers.length === 0 ? (
-                  <p className="text-sm text-muted-foreground">
+                  <p className="text-base text-muted-foreground">
                     尚未建立入口網站帳號。
                   </p>
                 ) : (
@@ -209,7 +209,7 @@ export default function ClientDetailPage({
                       >
                         <div className="space-y-1">
                           <p className="font-medium">{user.name || "未命名使用者"}</p>
-                          <p className="text-sm text-muted-foreground">
+                          <p className="text-base text-muted-foreground">
                             {user.email || "無 Email"}
                           </p>
                           <Badge variant="secondary">啟用中</Badge>

--- a/app/firm/[firmId]/client/[clientId]/portal/page.tsx
+++ b/app/firm/[firmId]/client/[clientId]/portal/page.tsx
@@ -127,7 +127,7 @@ export default function PortalDashboardPage({
             <Badge className="rounded-full bg-emerald-600 px-3 py-1 text-white hover:bg-emerald-600">
               更輕鬆報稅
             </Badge>
-            <div className="inline-flex items-center gap-2 rounded-full border border-emerald-200/70 bg-white/80 px-3 py-1 text-sm font-medium text-emerald-800 shadow-sm shadow-emerald-100/70">
+            <div className="inline-flex items-center gap-2 rounded-full border border-emerald-200/70 bg-white/80 px-3 py-1 text-base font-medium text-emerald-800 shadow-sm shadow-emerald-100/70">
               <ShieldCheck className="h-4 w-4" />
               專業團隊覆核
             </div>
@@ -137,12 +137,12 @@ export default function PortalDashboardPage({
             <h1 className="text-3xl font-bold tracking-tight text-slate-900 md:text-4xl">
               憑證上傳中心
             </h1>
-            <p className="max-w-2xl text-sm leading-6 text-slate-600 md:text-base">
+            <p className="max-w-2xl text-base leading-6 text-slate-600">
               {client.name}（統編: {client.tax_id}）
             </p>
           </div>
 
-          <div className="flex flex-wrap gap-3 text-sm">
+          <div className="flex flex-wrap gap-3 text-base">
             <div className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white/70 px-4 py-2 text-slate-600 shadow-sm">
               <Camera className="h-4 w-4 text-emerald-600" />
               拍照上傳、輕鬆補件
@@ -155,7 +155,7 @@ export default function PortalDashboardPage({
         </div>
       </section>
 
-      <div className="flex items-start gap-2.5 rounded-xl border border-sky-200/80 bg-sky-50/60 px-4 py-3 text-sm text-sky-800">
+      <div className="flex items-start gap-2.5 rounded-xl border border-sky-200/80 bg-sky-50/60 px-4 py-3 text-base text-sky-800">
         <Info className="mt-0.5 h-4 w-4 shrink-0 text-sky-500" />
         <p>電子發票不需上傳圖檔，SnapBooks 會自動從電子發票平台下載。</p>
       </div>
@@ -191,7 +191,7 @@ export default function PortalDashboardPage({
                     </Tooltip>
                   </TooltipProvider>
                 </div>
-                <p className="text-sm text-slate-600">
+                <p className="text-base text-slate-600">
                   建議先完成本期憑證上傳，避免接近截止日期。
                 </p>
               </div>
@@ -213,7 +213,7 @@ export default function PortalDashboardPage({
                 <h2 className="text-lg font-semibold text-slate-900">
                   其他期別
                 </h2>
-                <p className="text-sm text-slate-600">
+                <p className="text-base text-slate-600">
                   可隨時切換查看過往或未完成期別。
                 </p>
               </div>

--- a/app/firm/[firmId]/client/[clientId]/portal/period/[periodYYYMM]/page.tsx
+++ b/app/firm/[firmId]/client/[clientId]/portal/period/[periodYYYMM]/page.tsx
@@ -267,7 +267,7 @@ export default function PortalPeriodDetailPage({
                 {isLocked ? "已鎖定" : "進行中"}
               </Badge>
             </h1>
-            <p className="mt-2 text-sm text-slate-600 md:text-base">
+            <p className="mt-2 text-base text-slate-600">
               {client.name}（統編: {client.tax_id}）
             </p>
           </div>
@@ -318,10 +318,10 @@ export default function PortalPeriodDetailPage({
                   >
                     <div className="flex items-center justify-between gap-3">
                       <div>
-                        <p className="text-sm text-slate-500">{item.label}</p>
+                        <p className="text-base text-slate-500">{item.label}</p>
                         <p className="mt-2 text-2xl font-semibold text-slate-900">
                           {item.value}
-                          <span className="ml-1 text-sm font-medium text-slate-500">
+                          <span className="ml-1 text-base font-medium text-slate-500">
                             張
                           </span>
                         </p>
@@ -340,7 +340,7 @@ export default function PortalPeriodDetailPage({
             <CardHeader className="border-b border-slate-100/80">
               <CardTitle className="text-slate-900">操作指引</CardTitle>
             </CardHeader>
-            <CardContent className="space-y-3 pt-6 text-sm text-slate-600">
+            <CardContent className="space-y-3 pt-6 text-base text-slate-600">
               <p>1. 在「進項」與「銷項」分頁上傳本期文件並確認資料。</p>
               <p>2. 若有購買紙本發票，請至「字軌」分頁輸入起訖號。</p>
               {isLocked ? (

--- a/app/firm/[firmId]/dashboard/page.tsx
+++ b/app/firm/[firmId]/dashboard/page.tsx
@@ -17,11 +17,11 @@ export default async function DashboardPage({
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Active Firm</CardTitle>
+            <CardTitle className="text-base font-medium">Active Firm</CardTitle>
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold">Connected</div>
-            <p className="text-xs text-muted-foreground mt-1 truncate">
+            <p className="text-sm text-muted-foreground mt-1 truncate">
               ID: {firmId}
             </p>
           </CardContent>

--- a/app/firm/[firmId]/invoice/page.tsx
+++ b/app/firm/[firmId]/invoice/page.tsx
@@ -230,7 +230,7 @@ export default function InvoicePage({
         </CardHeader>
         <CardContent className="flex gap-4">
           <div className="flex-1">
-            <label className="text-sm font-medium mb-2 block">狀態</label>
+            <label className="text-base font-medium mb-2 block">狀態</label>
             <Select value={statusFilter} onValueChange={setStatusFilter}>
               <SelectTrigger>
                 <SelectValue />
@@ -246,7 +246,7 @@ export default function InvoicePage({
             </Select>
           </div>
           <div className="flex-1">
-            <label className="text-sm font-medium mb-2 block">類型</label>
+            <label className="text-base font-medium mb-2 block">類型</label>
             <Select value={typeFilter} onValueChange={setTypeFilter}>
               <SelectTrigger>
                 <SelectValue />

--- a/app/firm/[firmId]/layout.tsx
+++ b/app/firm/[firmId]/layout.tsx
@@ -22,7 +22,7 @@ async function FirmName({ params }: { params: Promise<{ firmId: string }> }) {
     .single();
 
   return (
-    <span className="text-sm font-semibold truncate max-w-[200px]">
+    <span className="text-base font-semibold truncate max-w-[200px]">
       {data?.name || "Unknown Firm"}
     </span>
   );

--- a/components/allowance-review-dialog.tsx
+++ b/components/allowance-review-dialog.tsx
@@ -619,7 +619,7 @@ export function AllowanceReviewDialog({
             ) : (
               <div className="flex flex-col items-center gap-2 text-muted-foreground p-4 text-center">
                 <p>無文件預覽</p>
-                {previewText && <p className="text-sm">{previewText}</p>}
+                {previewText && <p className="text-base">{previewText}</p>}
               </div>
             )}
           </div>

--- a/components/allowance-table.tsx
+++ b/components/allowance-table.tsx
@@ -169,7 +169,7 @@ export function AllowanceTable({
     const barClass = inOrOut === "in" ? "bg-sky-500" : "bg-orange-500";
 
     return (
-      <span className="inline-flex items-center gap-2 text-sm text-muted-foreground">
+      <span className="inline-flex items-center gap-2 text-base text-muted-foreground">
         <span className={`h-4 w-0.5 rounded-full ${barClass}`} />
         {label}
       </span>
@@ -243,7 +243,7 @@ export function AllowanceTable({
   return (
     <div className="relative w-full overflow-auto max-h-[60vh] border rounded-md">
       <TooltipProvider>
-        <table className="w-full caption-bottom text-sm table-fixed">
+        <table className="w-full caption-bottom text-base table-fixed">
           <TableHeader className="sticky top-0 z-10 bg-background">
             <TableRow>
               <TableHead className="w-[88px]">縮圖</TableHead>
@@ -344,7 +344,7 @@ export function AllowanceTable({
                     >
                       <div className="space-y-1">
                         <div>{getTypeIndicator(allowance.in_or_out)}</div>
-                        <p className="truncate text-xs text-muted-foreground">
+                        <p className="truncate text-sm text-muted-foreground">
                           {extractedData?.allowanceType || "尚未擷取"}
                         </p>
                       </div>

--- a/components/bulk-extraction-progress.tsx
+++ b/components/bulk-extraction-progress.tsx
@@ -95,7 +95,7 @@ export function BulkExtractionProgress({
       {/* Progress indicator while active */}
       {isBulkActive && progress && (
         <div className="flex items-center gap-3 flex-1">
-          <div className="flex items-center gap-2 text-sm text-muted-foreground whitespace-nowrap">
+          <div className="flex items-center gap-2 text-base text-muted-foreground whitespace-nowrap">
             <Loader2 className="h-4 w-4 animate-spin" />
             <span>
               AI 批次處理中 {doneCount}/{total}
@@ -117,7 +117,7 @@ export function BulkExtractionProgress({
 
       {/* Completion summary (shown briefly after done, if there were failures) */}
       {!isBulkActive && progress && processingCount === 0 && failedCount > 0 && (
-        <div className="flex items-center gap-2 text-sm">
+        <div className="flex items-center gap-2 text-base">
           <XCircle className="h-4 w-4 text-destructive" />
           <span className="text-destructive">
             {failedCount} 筆 AI 提取失敗

--- a/components/company-setup-check-client.tsx
+++ b/components/company-setup-check-client.tsx
@@ -335,7 +335,7 @@ export function CompanySetupCheckClient() {
                 {opt.label}
               </span>
               {opt.disabled && opt.disableMsg && (
-                <span className="mt-1 block text-xs text-red-400">
+                <span className="mt-1 block text-sm text-red-400">
                   ({opt.disableMsg})
                 </span>
               )}

--- a/components/document-upload-section.tsx
+++ b/components/document-upload-section.tsx
@@ -204,7 +204,7 @@ export const DocumentUploadSection = forwardRef<
         </CardHeader>
         <CardContent className="pt-6">
           {isLocked ? (
-            <p className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600">
+            <p className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-base text-slate-600">
               此期別已鎖定，無法上傳新檔案。
             </p>
           ) : (

--- a/components/dropzone.tsx
+++ b/components/dropzone.tsx
@@ -88,7 +88,7 @@ const DropzoneContent = ({ className }: { className?: string }) => {
     return (
       <div className={cn('flex flex-row items-center gap-x-2 justify-center', className)}>
         <CheckCircle size={16} className="text-primary" />
-        <p className="text-primary text-sm">
+        <p className="text-primary text-base">
           Successfully uploaded {files.length} file{files.length > 1 ? 's' : ''}
         </p>
       </div>
@@ -125,11 +125,11 @@ const DropzoneContent = ({ className }: { className?: string }) => {
             )}
 
             <div className="shrink grow flex flex-col items-start truncate">
-              <p title={file.name} className="text-sm truncate max-w-full">
+              <p title={file.name} className="text-base truncate max-w-full">
                 {file.name}
               </p>
               {file.errors.length > 0 ? (
-                <p className="text-xs text-destructive">
+                <p className="text-sm text-destructive">
                   {file.errors
                     .map((e) =>
                       e.message.startsWith('File is larger than')
@@ -139,13 +139,13 @@ const DropzoneContent = ({ className }: { className?: string }) => {
                     .join(', ')}
                 </p>
               ) : loading && !isSuccessfullyUploaded ? (
-                <p className="text-xs text-muted-foreground">Uploading file...</p>
+                <p className="text-sm text-muted-foreground">Uploading file...</p>
               ) : !!fileError ? (
-                <p className="text-xs text-destructive">Failed to upload: {fileError.message}</p>
+                <p className="text-sm text-destructive">Failed to upload: {fileError.message}</p>
               ) : isSuccessfullyUploaded ? (
-                <p className="text-xs text-primary">Successfully uploaded file</p>
+                <p className="text-sm text-primary">Successfully uploaded file</p>
               ) : (
-                <p className="text-xs text-muted-foreground">{formatBytes(file.size, 2)}</p>
+                <p className="text-sm text-muted-foreground">{formatBytes(file.size, 2)}</p>
               )}
             </div>
 
@@ -163,7 +163,7 @@ const DropzoneContent = ({ className }: { className?: string }) => {
         )
       })}
       {exceedMaxFiles && (
-        <p className="text-sm text-left mt-2 text-destructive">
+        <p className="text-base text-left mt-2 text-destructive">
           You may upload only up to {maxFiles} files, please remove {files.length - maxFiles} file
           {files.length - maxFiles > 1 ? 's' : ''}.
         </p>
@@ -200,12 +200,12 @@ const DropzoneEmptyState = ({ className }: { className?: string }) => {
   return (
     <div className={cn('flex flex-col items-center gap-y-2', className)}>
       <Upload size={20} className="text-muted-foreground" />
-      <p className="text-sm">
+      <p className="text-base">
         Upload{!!maxFiles && maxFiles > 1 ? ` ${maxFiles}` : ''} file
         {!maxFiles || maxFiles > 1 ? 's' : ''}
       </p>
       <div className="flex flex-col items-center gap-y-1">
-        <p className="text-xs text-muted-foreground">
+        <p className="text-sm text-muted-foreground">
           Drag and drop or{' '}
           <a
             onClick={() => inputRef.current?.click()}
@@ -216,7 +216,7 @@ const DropzoneEmptyState = ({ className }: { className?: string }) => {
           to upload
         </p>
         {maxFileSize !== Number.POSITIVE_INFINITY && (
-          <p className="text-xs text-muted-foreground">
+          <p className="text-sm text-muted-foreground">
             Maximum file size: {formatBytes(maxFileSize, 2)}
           </p>
         )}

--- a/components/file-preview-dialog.tsx
+++ b/components/file-preview-dialog.tsx
@@ -123,7 +123,7 @@ export function FilePreviewDialog({
               <span>載入預覽中...</span>
             </div>
           ) : !previewUrl ? (
-            <div className="flex h-full w-full items-center justify-center text-sm text-muted-foreground">
+            <div className="flex h-full w-full items-center justify-center text-base text-muted-foreground">
               {isInlinePreviewSupported
                 ? "無法載入預覽"
                 : "此檔案類型不支援內嵌預覽"}
@@ -144,7 +144,7 @@ export function FilePreviewDialog({
               sandbox="allow-scripts allow-same-origin"
             />
           ) : (
-            <div className="flex h-full w-full items-center justify-center text-sm text-muted-foreground">
+            <div className="flex h-full w-full items-center justify-center text-base text-muted-foreground">
               此檔案類型不支援內嵌預覽
             </div>
           )}

--- a/components/firm-sidebar.tsx
+++ b/components/firm-sidebar.tsx
@@ -61,12 +61,12 @@ export function FirmSidebar() {
       </SidebarHeader>
       <SidebarContent>
         <SidebarGroup>
-          <SidebarGroupLabel>管理模組</SidebarGroupLabel>
+          <SidebarGroupLabel className="text-sm">管理模組</SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
               {items.map((item) => (
                 <SidebarMenuItem key={item.title}>
-                  <SidebarMenuButton asChild tooltip={item.title}>
+                  <SidebarMenuButton asChild tooltip={item.title} className="text-base">
                     <Link href={item.url}>
                       <item.icon />
                       <span>{item.title}</span>
@@ -81,7 +81,7 @@ export function FirmSidebar() {
       <SidebarFooter>
         <SidebarMenu>
           <SidebarMenuItem>
-            <SidebarMenuButton onClick={handleLogout} className="text-destructive hover:text-destructive hover:bg-destructive/10">
+            <SidebarMenuButton onClick={handleLogout} className="text-base text-destructive hover:text-destructive hover:bg-destructive/10">
               <LogOut className="size-4" />
               <span>Logout</span>
             </SidebarMenuButton>

--- a/components/firm-sidebar.tsx
+++ b/components/firm-sidebar.tsx
@@ -51,7 +51,7 @@ export function FirmSidebar() {
                 <div className="flex aspect-square size-8 items-center justify-center rounded-lg bg-sidebar-primary text-sidebar-primary-foreground">
                   <LayoutDashboard className="size-4" />
                 </div>
-                <div className="grid flex-1 text-left text-sm leading-tight">
+                <div className="grid flex-1 text-left leading-tight">
                   <span className="truncate font-semibold text-lg">AI Accounting</span>
                 </div>
               </Link>

--- a/components/forgot-password-form.tsx
+++ b/components/forgot-password-form.tsx
@@ -53,7 +53,7 @@ export function ForgotPasswordForm({
             <CardDescription>已寄送密碼重設連結</CardDescription>
           </CardHeader>
           <CardContent>
-            <p className="text-sm text-muted-foreground">
+            <p className="text-base text-muted-foreground">
               如果您曾使用此電子郵件註冊，將會收到密碼重設郵件。
             </p>
           </CardContent>
@@ -80,12 +80,12 @@ export function ForgotPasswordForm({
                     onChange={(e) => setEmail(e.target.value)}
                   />
                 </div>
-                {error && <p className="text-sm text-red-500">{error}</p>}
+                {error && <p className="text-base text-red-500">{error}</p>}
                 <Button type="submit" className="w-full" disabled={isLoading}>
                   {isLoading ? "寄送中..." : "寄送重設郵件"}
                 </Button>
               </div>
-              <div className="mt-4 text-center text-sm">
+              <div className="mt-4 text-center text-base">
                 <Link
                   href="/auth/login"
                   className="underline underline-offset-4"

--- a/components/invoice-helper-form.tsx
+++ b/components/invoice-helper-form.tsx
@@ -126,7 +126,7 @@ export function InvoiceHelperForm({ data, onChange }: InvoiceHelperFormProps) {
           </Label>
           <div className="grid gap-3 sm:grid-cols-[180px_1fr]">
             <div>
-              <Label className="text-sm text-slate-600 mb-1 block">
+              <Label className="text-base text-slate-600 mb-1 block">
                 統一編號
               </Label>
               <Input
@@ -142,7 +142,7 @@ export function InvoiceHelperForm({ data, onChange }: InvoiceHelperFormProps) {
               />
             </div>
             <div>
-              <Label className="text-sm text-slate-600 mb-1 block flex items-center gap-1">
+              <Label className="text-base text-slate-600 mb-1 block flex items-center gap-1">
                 公司名稱
                 {data.buyerTaxId.length === 8 && !data.buyerName && (
                   <Loader2 className="h-3 w-3 animate-spin text-slate-400" />
@@ -273,15 +273,15 @@ export function InvoiceHelperForm({ data, onChange }: InvoiceHelperFormProps) {
                 </div>
                 <div className="grid grid-cols-3 gap-2">
                   <div>
-                    <Label className="text-sm text-slate-500 mb-1 block">數量</Label>
+                    <Label className="text-base text-slate-500 mb-1 block">數量</Label>
                     <Input {...quantityProps} className="h-11 text-lg text-center" />
                   </div>
                   <div>
-                    <Label className="text-sm text-slate-500 mb-1 block">單價</Label>
+                    <Label className="text-base text-slate-500 mb-1 block">單價</Label>
                     <Input {...unitPriceProps} className="h-11 text-lg text-right font-mono" />
                   </div>
                   <div>
-                    <Label className="text-sm text-slate-500 mb-1 block">金額</Label>
+                    <Label className="text-base text-slate-500 mb-1 block">金額</Label>
                     <div className="h-11 flex items-center justify-end font-mono text-lg text-slate-700 tabular-nums px-2 bg-white rounded-md border border-slate-200">
                       {item.amount ? item.amount.toLocaleString() : "-"}
                     </div>
@@ -306,14 +306,14 @@ export function InvoiceHelperForm({ data, onChange }: InvoiceHelperFormProps) {
       {/* Bidirectional Tax Totals (only for 應稅) */}
       {data.taxType === "應稅" && (
         <div className="rounded-lg border border-slate-200 bg-slate-50 p-4 space-y-3">
-          <p className="text-sm text-slate-500">
+          <p className="text-base text-slate-500">
             {data.variant === "二聯式"
               ? "二聯式發票品項金額為含稅價，系統自動反算未稅金額"
               : "三聯式發票品項金額為未稅價，系統自動加計營業稅"}
           </p>
           <div className="grid gap-3 sm:grid-cols-2">
             <div>
-              <Label className="text-sm text-slate-600 mb-1 block">
+              <Label className="text-base text-slate-600 mb-1 block">
                 未稅金額（銷售額）
               </Label>
               <Input
@@ -331,7 +331,7 @@ export function InvoiceHelperForm({ data, onChange }: InvoiceHelperFormProps) {
               />
             </div>
             <div>
-              <Label className="text-sm text-slate-600 mb-1 block">
+              <Label className="text-base text-slate-600 mb-1 block">
                 含稅金額（總計）
               </Label>
               <Input

--- a/components/invoice-review-dialog.tsx
+++ b/components/invoice-review-dialog.tsx
@@ -990,7 +990,7 @@ export function InvoiceReviewDialog({
                         </PopoverContent>
                       </Popover>
                       {isPeriodMismatch && invoice?.year_month && (
-                        <div className="flex items-center gap-1.5 mt-1 text-xs font-medium text-orange-600 bg-orange-50 p-1.5 rounded border border-orange-200">
+                        <div className="flex items-center gap-1.5 mt-1 text-sm font-medium text-orange-600 bg-orange-50 p-1.5 rounded border border-orange-200">
                           <AlertCircle className="h-3.5 w-3.5 shrink-0" />
                           <span>
                             期別不符 ({RocPeriod.fromYYYMM(invoice.year_month).format()})
@@ -1107,7 +1107,7 @@ export function InvoiceReviewDialog({
               {(isAiTotalMismatch || isTaxAmountWarning) && (
                 <div className="space-y-1.5">
                   {isAiTotalMismatch && (
-                    <div className="flex items-center gap-1.5 text-xs font-medium text-orange-600 bg-orange-50 p-1.5 rounded border border-orange-200">
+                    <div className="flex items-center gap-1.5 text-sm font-medium text-orange-600 bg-orange-50 p-1.5 rounded border border-orange-200">
                       <AlertCircle className="h-3.5 w-3.5 shrink-0" />
                       <span>
                         AI 辨識總計為 {aiExtractedTotal}，與銷售額 + 稅額 ({computedTotal}) 不符，請確認銷售額與稅額是否正確
@@ -1115,7 +1115,7 @@ export function InvoiceReviewDialog({
                     </div>
                   )}
                   {isTaxAmountWarning && (
-                    <div className="flex items-center gap-1.5 text-xs font-medium text-red-600 bg-red-50 p-1.5 rounded border border-red-200">
+                    <div className="flex items-center gap-1.5 text-sm font-medium text-red-600 bg-red-50 p-1.5 rounded border border-red-200">
                       <AlertCircle className="h-3.5 w-3.5 shrink-0" />
                       <span>
                         {isTaxEmbeddedInvoice
@@ -1175,7 +1175,7 @@ export function InvoiceReviewDialog({
                         />
                       </FormControl>
                       {isSellerTaxIdInvalid && (
-                        <div className="flex items-center gap-1.5 mt-2 text-xs font-medium text-red-600 bg-red-50 p-2 rounded border border-red-200">
+                        <div className="flex items-center gap-1.5 mt-2 text-sm font-medium text-red-600 bg-red-50 p-2 rounded border border-red-200">
                           <AlertCircle className="h-3.5 w-3.5 shrink-0" />
                           <span>統一編號檢核碼不符</span>
                         </div>
@@ -1234,7 +1234,7 @@ export function InvoiceReviewDialog({
                         />
                       </FormControl>
                       {isBuyerTaxIdInvalid && (
-                        <div className="flex items-center gap-1.5 mt-2 text-xs font-medium text-red-600 bg-red-50 p-2 rounded border border-red-200">
+                        <div className="flex items-center gap-1.5 mt-2 text-sm font-medium text-red-600 bg-red-50 p-2 rounded border border-red-200">
                           <AlertCircle className="h-3.5 w-3.5 shrink-0" />
                           <span>統一編號檢核碼不符</span>
                         </div>
@@ -1457,13 +1457,13 @@ export function InvoiceReviewDialog({
             {/* Linked Allowances Section */}
             {linkedAllowances.length > 0 && (
               <div className="mt-3 space-y-2 border-t pt-3">
-                <p className="text-sm font-medium">
+                <p className="text-base font-medium">
                   相關折讓單 ({linkedAllowances.length})
                 </p>
                 {linkedAllowances.map((allowance) => (
                   <div
                     key={allowance.id}
-                    className="flex items-center justify-between text-sm p-2 bg-muted rounded-md"
+                    className="flex items-center justify-between text-base p-2 bg-muted rounded-md"
                   >
                     <div className="flex items-center gap-3">
                       <span className="font-mono">
@@ -1480,7 +1480,7 @@ export function InvoiceReviewDialog({
                           allowance.extracted_data?.amount || 0
                         ).toLocaleString()}
                       </span>
-                      <span className="text-xs text-muted-foreground">
+                      <span className="text-sm text-muted-foreground">
                         {allowance.status === "confirmed" ? "已確認" : "待確認"}
                       </span>
                     </div>

--- a/components/invoice-table.tsx
+++ b/components/invoice-table.tsx
@@ -175,7 +175,7 @@ export function InvoiceTable({
     const barClass = inOrOut === "in" ? "bg-sky-500" : "bg-orange-500";
 
     return (
-      <span className="inline-flex items-center gap-2 text-sm text-muted-foreground">
+      <span className="inline-flex items-center gap-2 text-base text-muted-foreground">
         <span className={`h-4 w-0.5 rounded-full ${barClass}`} />
         {label}
       </span>
@@ -244,7 +244,7 @@ export function InvoiceTable({
 
   return (
     <div className="relative w-full overflow-auto max-h-[60vh] border rounded-md">
-      <table className="w-full caption-bottom text-sm table-fixed">
+      <table className="w-full caption-bottom text-base table-fixed">
         <TableHeader className="sticky top-0 z-10 bg-background">
           <TableRow>
             <TableHead className="w-[88px]">縮圖</TableHead>
@@ -358,7 +358,7 @@ export function InvoiceTable({
                 >
                   <div className="space-y-1">
                     <div>{getTypeIndicator(invoice.in_or_out)}</div>
-                    <p className="truncate text-xs text-muted-foreground">
+                    <p className="truncate text-sm text-muted-foreground">
                       {invoice.extracted_data?.invoiceType || "尚未擷取"}
                     </p>
                   </div>

--- a/components/login-form.tsx
+++ b/components/login-form.tsx
@@ -81,7 +81,7 @@ export function LoginForm({
                   </Label>
                   <Link
                     href="/auth/forgot-password"
-                    className="ml-auto inline-block text-sm text-emerald-600 underline-offset-4 hover:underline"
+                    className="ml-auto inline-block text-base text-emerald-600 underline-offset-4 hover:underline"
                   >
                     忘記密碼？
                   </Link>
@@ -96,7 +96,7 @@ export function LoginForm({
                 />
               </div>
               {error && (
-                <p className="rounded-lg bg-red-50 px-4 py-2 text-sm text-red-600">
+                <p className="rounded-lg bg-red-50 px-4 py-2 text-base text-red-600">
                   {error}
                 </p>
               )}

--- a/components/mobile-nav.tsx
+++ b/components/mobile-nav.tsx
@@ -38,7 +38,7 @@ export function MobileNav() {
 
           {/* 小工具 section */}
           <div className="pt-2 border-t border-slate-100 mt-2">
-            <span className="text-xs font-semibold uppercase tracking-wider text-slate-400">
+            <span className="text-sm font-semibold uppercase tracking-wider text-slate-400">
               小工具
             </span>
             <div className="mt-1 flex flex-col gap-1">

--- a/components/mobile-upload-actions.tsx
+++ b/components/mobile-upload-actions.tsx
@@ -133,7 +133,7 @@ export function MobileUploadActions({
 
   return (
     <div className="mb-3 flex flex-col gap-2">
-      <p className="text-xs text-muted-foreground">
+      <p className="text-sm text-muted-foreground">
         手機可直接拍照上傳，或從相簿選取檔案。
       </p>
       <div className="flex flex-wrap gap-2">

--- a/components/portal-bottom-nav.tsx
+++ b/components/portal-bottom-nav.tsx
@@ -32,7 +32,7 @@ export function PortalBottomNav() {
       >
         <Link
           href={portalHome}
-          className={`flex flex-col items-center gap-1 px-4 py-2 text-xs font-medium transition-colors ${
+          className={`flex flex-col items-center gap-1 px-4 py-2 text-sm font-medium transition-colors ${
             isHome
               ? "text-emerald-600"
               : "text-slate-500 active:text-emerald-600"
@@ -45,7 +45,7 @@ export function PortalBottomNav() {
         <button
           type="button"
           onClick={handleLogout}
-          className="flex flex-col items-center gap-1 px-4 py-2 text-xs font-medium text-slate-500 transition-colors active:text-red-600"
+          className="flex flex-col items-center gap-1 px-4 py-2 text-sm font-medium text-slate-500 transition-colors active:text-red-600"
         >
           <LogOut className="h-5 w-5" />
           <span>登出</span>

--- a/components/portal-sidebar.tsx
+++ b/components/portal-sidebar.tsx
@@ -40,7 +40,7 @@ export function PortalSidebar() {
                 <div className="flex aspect-square size-8 items-center justify-center rounded-lg bg-sidebar-primary text-sidebar-primary-foreground">
                   <LayoutDashboard className="size-4" />
                 </div>
-                <div className="grid flex-1 text-left text-sm leading-tight">
+                <div className="grid flex-1 text-left leading-tight">
                   <span className="truncate font-semibold text-lg">客戶中心</span>
                 </div>
               </Link>

--- a/components/portal-sidebar.tsx
+++ b/components/portal-sidebar.tsx
@@ -50,11 +50,11 @@ export function PortalSidebar() {
       </SidebarHeader>
       <SidebarContent>
         <SidebarGroup>
-          <SidebarGroupLabel>入口網站</SidebarGroupLabel>
+          <SidebarGroupLabel className="text-sm">入口網站</SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
               <SidebarMenuItem>
-                <SidebarMenuButton asChild tooltip="首頁">
+                <SidebarMenuButton asChild tooltip="首頁" className="text-base">
                   <Link href={dashboardUrl}>
                     <LayoutDashboard />
                     <span>首頁</span>
@@ -70,7 +70,7 @@ export function PortalSidebar() {
           <SidebarMenuItem>
             <SidebarMenuButton
               onClick={handleLogout}
-              className="text-destructive hover:text-destructive hover:bg-destructive/10"
+              className="text-base text-destructive hover:text-destructive hover:bg-destructive/10"
             >
               <LogOut className="size-4" />
               <span>Logout</span>

--- a/components/portal-upload-fab.tsx
+++ b/components/portal-upload-fab.tsx
@@ -166,10 +166,10 @@ export function PortalUploadFab({
                     <div className="rounded-xl bg-emerald-100 p-2.5 text-emerald-700">
                       <Icon className="h-5 w-5" />
                     </div>
-                    <span className="text-sm font-medium text-slate-900">
+                    <span className="text-base font-medium text-slate-900">
                       {docType.label}
                     </span>
-                    <span className="text-xs text-slate-500">
+                    <span className="text-sm text-slate-500">
                       {docType.description}
                     </span>
                   </button>

--- a/components/range-management.tsx
+++ b/components/range-management.tsx
@@ -250,12 +250,12 @@ export function RangeManagement({
                         <Input placeholder="例如: RT33662450" {...field} />
                       </FormControl>
                       {isHandwrittenInvoiceType && (
-                        <p className="text-xs text-muted-foreground">
+                        <p className="text-sm text-muted-foreground">
                           手開發票起始號末兩碼需為 00 或 50，一本50張。
                         </p>
                       )}
                       {cashierInvoiceTypes.has(selectedInvoiceType) && (
-                        <p className="text-xs text-muted-foreground">
+                        <p className="text-sm text-muted-foreground">
                           收銀機發票一卷250張。
                         </p>
                       )}

--- a/components/report-generation.tsx
+++ b/components/report-generation.tsx
@@ -325,7 +325,7 @@ export function ReportGeneration({
               </div>
 
               <div className="space-y-4 border rounded-md p-4">
-                <h3 className="font-medium text-sm">申報人資訊</h3>
+                <h3 className="font-medium text-base">申報人資訊</h3>
                 <div className="grid grid-cols-2 gap-4">
                   <FormField
                     control={tetUForm.control}
@@ -393,7 +393,7 @@ export function ReportGeneration({
               </div>
 
               <div className="space-y-4 border rounded-md p-4">
-                <h3 className="font-medium text-sm">稅額調整欄位</h3>
+                <h3 className="font-medium text-base">稅額調整欄位</h3>
                 <div className="grid grid-cols-3 gap-4">
                   <FormField
                     control={tetUForm.control}

--- a/components/sign-up-form.tsx
+++ b/components/sign-up-form.tsx
@@ -117,12 +117,12 @@ export function SignUpForm({
                   onChange={(e) => setRepeatPassword(e.target.value)}
                 />
               </div>
-              {error && <p className="text-sm text-red-500">{error}</p>}
+              {error && <p className="text-base text-red-500">{error}</p>}
               <Button type="submit" className="w-full" disabled={isLoading}>
                 {isLoading ? "Creating an account..." : "Sign up"}
               </Button>
             </div>
-            <div className="mt-4 text-center text-sm">
+            <div className="mt-4 text-center text-base">
               Already have an account?{" "}
               <Link href="/auth/login" className="underline underline-offset-4">
                 Login

--- a/components/status-filter-bar.tsx
+++ b/components/status-filter-bar.tsx
@@ -62,7 +62,7 @@ export function StatusFilterBar({
             type="button"
             onClick={() => onStatusChange(option.value)}
             className={cn(
-              "inline-flex shrink-0 items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-colors",
+              "inline-flex shrink-0 items-center gap-1.5 rounded-full border px-3 py-1 text-sm font-medium transition-colors",
               isActive
                 ? option.activeClass
                 : "border-transparent bg-muted/50 text-muted-foreground hover:bg-muted hover:text-foreground",

--- a/components/table-pagination.tsx
+++ b/components/table-pagination.tsx
@@ -25,11 +25,11 @@ export function TablePagination({
 
   return (
     <div className="flex items-center justify-between px-2 py-3">
-      <p className="text-sm text-muted-foreground">
+      <p className="text-base text-muted-foreground">
         顯示 {start}-{end} 共 {totalItems} 筆
       </p>
       <div className="flex items-center gap-2">
-        <span className="text-sm text-muted-foreground">
+        <span className="text-base text-muted-foreground">
           第 {page + 1} / {totalPages} 頁
         </span>
         <Button

--- a/components/tax-calendar-reminder.tsx
+++ b/components/tax-calendar-reminder.tsx
@@ -44,7 +44,7 @@ export function TaxCalendarReminder() {
           <AccordionTrigger className="px-4 py-3 hover:no-underline">
             <div className="flex items-center gap-2">
               <CalendarDays className="h-4 w-4 text-slate-500" />
-              <span className="text-sm font-medium text-slate-700">
+              <span className="text-base font-medium text-slate-700">
                 下次截止：{formatDate(nextEvent)}{" "}
                 {nextEvents.length === 1
                   ? nextEvent.label
@@ -53,7 +53,7 @@ export function TaxCalendarReminder() {
               <Badge
                 variant="outline"
                 className={cn(
-                  "rounded-full px-2 py-0 text-xs font-medium",
+                  "rounded-full px-2 py-0 text-sm font-medium",
                   urgencyColor(nextEvent.daysUntil),
                 )}
               >
@@ -68,7 +68,7 @@ export function TaxCalendarReminder() {
                 <div
                   key={`${event.month}-${event.day}-${event.label}`}
                   className={cn(
-                    "flex items-center gap-3 rounded-lg px-3 py-2 text-sm",
+                    "flex items-center gap-3 rounded-lg px-3 py-2 text-base",
                     event.isNext
                       ? "border-l-2 border-emerald-500 bg-emerald-50/60 font-medium text-slate-900"
                       : "text-slate-600",
@@ -82,7 +82,7 @@ export function TaxCalendarReminder() {
                     <Badge
                       variant="outline"
                       className={cn(
-                        "rounded-full px-2 py-0 text-xs",
+                        "rounded-full px-2 py-0 text-sm",
                         urgencyColor(event.daysUntil),
                       )}
                     >

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -449,7 +449,7 @@ const SidebarGroupLabel = React.forwardRef<
       ref={ref}
       data-sidebar="group-label"
       className={cn(
-        "flex h-8 shrink-0 items-center rounded-md px-2 text-sm font-medium text-sidebar-foreground/70 outline-none ring-sidebar-ring transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        "flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 outline-none ring-sidebar-ring transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
         "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
         className
       )}
@@ -531,7 +531,7 @@ const sidebarMenuButtonVariants = cva(
           "bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]",
       },
       size: {
-        default: "h-8 text-base",
+        default: "h-8 text-sm",
         sm: "h-7 text-xs",
         lg: "h-12 text-sm group-data-[collapsible=icon]:!p-0",
       },

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -449,7 +449,7 @@ const SidebarGroupLabel = React.forwardRef<
       ref={ref}
       data-sidebar="group-label"
       className={cn(
-        "flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 outline-none ring-sidebar-ring transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        "flex h-8 shrink-0 items-center rounded-md px-2 text-sm font-medium text-sidebar-foreground/70 outline-none ring-sidebar-ring transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
         "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
         className
       )}
@@ -531,7 +531,7 @@ const sidebarMenuButtonVariants = cva(
           "bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]",
       },
       size: {
-        default: "h-8 text-sm",
+        default: "h-8 text-base",
         sm: "h-7 text-xs",
         lg: "h-12 text-sm group-data-[collapsible=icon]:!p-0",
       },

--- a/components/update-password-form.tsx
+++ b/components/update-password-form.tsx
@@ -64,7 +64,7 @@ export function UpdatePasswordForm({
                   onChange={(e) => setPassword(e.target.value)}
                 />
               </div>
-              {error && <p className="text-sm text-red-500">{error}</p>}
+              {error && <p className="text-base text-red-500">{error}</p>}
               <Button type="submit" className="w-full" disabled={isLoading}>
                 {isLoading ? "儲存中..." : "儲存新密碼"}
               </Button>

--- a/components/upload-queue-list.tsx
+++ b/components/upload-queue-list.tsx
@@ -54,7 +54,7 @@ export function UploadQueueList({
           <CardTitle>{title}</CardTitle>
         </CardHeader>
         <CardContent>
-          <p className="text-sm text-muted-foreground">目前沒有待辨識檔案。</p>
+          <p className="text-base text-muted-foreground">目前沒有待辨識檔案。</p>
         </CardContent>
       </Card>
     );
@@ -70,7 +70,7 @@ export function UploadQueueList({
           {items.map((item) => (
             <li
               key={item.id}
-              className="w-44 shrink-0 rounded-md border bg-muted/20 p-2 text-xs md:w-auto md:shrink"
+              className="w-44 shrink-0 rounded-md border bg-muted/20 p-2 text-sm md:w-auto md:shrink"
               title={item.filename}
             >
               <div className="mb-2 flex h-24 w-full items-center justify-center overflow-hidden rounded border bg-background">
@@ -94,10 +94,10 @@ export function UploadQueueList({
                       </button>
                     </DialogTrigger>
                     <DialogContent className="w-[95vw] max-w-3xl p-3 sm:p-4">
-                      <DialogTitle className="truncate text-sm sm:text-base">
+                      <DialogTitle className="truncate text-base">
                         {item.filename}
                       </DialogTitle>
-                      <DialogDescription className="text-xs">
+                      <DialogDescription className="text-sm">
                         點擊縮圖可放大預覽
                       </DialogDescription>
                       <div className="relative mt-1 h-[70vh] w-full overflow-hidden rounded-md border bg-background">
@@ -159,7 +159,7 @@ export function UploadQueueList({
             </Button>
           </div>
         ) : (
-          <p className="text-center text-xs text-muted-foreground">
+          <p className="text-center text-sm text-muted-foreground">
             已載入全部待辨識檔案
           </p>
         )}


### PR DESCRIPTION
## Summary
- Establish text sizing convention: `text-base` (16px) as default, `text-sm` (14px) for secondary text only, never `text-xs` in app-owned components
- Update 32 files across sidebars, tables, forms, dialogs, upload components, auth pages, and portal pages
- Add text sizing convention to CLAUDE.md for future consistency
- Leave shadcn/ui primitives untouched to avoid blocking future upgrades

## Test plan
- [ ] Check admin sidebar text sizes (manage module nav items)
- [ ] Check portal sidebar text sizes (portal nav items)
- [ ] Check firm name in page header
- [ ] Verify invoice/allowance tables are readable
- [ ] Check review dialogs (validation warnings, linked allowances)
- [ ] Check auth pages (login, sign-up, forgot password)
- [ ] Check portal home and period detail pages
- [ ] Check upload flows (dropzone, queue list, FAB menu)
- [ ] Spot-check on mobile viewport for portal pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)