### PR TITLE
Voucher / journal-entry UI scaffold backed by in-memory store (phase 1+2)

### DIFF
--- a/app/firm/[firmId]/client/[clientId]/period/[periodYYYMM]/page.tsx
+++ b/app/firm/[firmId]/client/[clientId]/period/[periodYYYMM]/page.tsx
@@ -6,7 +6,8 @@ import { createClient as createSupabaseClient } from "@/lib/supabase/client";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Loader2, ArrowLeft, Lock, Unlock, Plus, FileText } from "lucide-react";
+import { Loader2, ArrowLeft, Lock, Unlock, Plus, FileText, BookOpen } from "lucide-react";
+import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { InvoiceTable } from "@/components/invoice-table";
 import { AllowanceTable } from "@/components/allowance-table";
@@ -531,9 +532,18 @@ export default function PeriodDetailPage({
           {/* Invoices Section */}
           <Card>
             <CardHeader className="pb-3">
-              <CardTitle className="text-lg">
-                發票 ({invoiceTotalCount})
-              </CardTitle>
+              <div className="flex items-start justify-between gap-2">
+                <CardTitle className="text-lg">
+                  發票 ({invoiceTotalCount})
+                </CardTitle>
+                <Link
+                  href={`/firm/${firmId}/client/${clientId}/voucher`}
+                  className="inline-flex items-center gap-1 text-base text-muted-foreground hover:text-foreground"
+                >
+                  <BookOpen className="size-4" />
+                  已 confirmed 之發票會產生 draft 傳票 →
+                </Link>
+              </div>
               <StatusFilterBar
                 activeStatus={invoiceStatusFilter}
                 onStatusChange={handleInvoiceStatusFilterChange}
@@ -570,9 +580,18 @@ export default function PeriodDetailPage({
           {/* Allowances Section */}
           <Card>
             <CardHeader className="pb-3">
-              <CardTitle className="text-lg">
-                折讓 ({allowanceTotalCount})
-              </CardTitle>
+              <div className="flex items-start justify-between gap-2">
+                <CardTitle className="text-lg">
+                  折讓 ({allowanceTotalCount})
+                </CardTitle>
+                <Link
+                  href={`/firm/${firmId}/client/${clientId}/voucher`}
+                  className="inline-flex items-center gap-1 text-base text-muted-foreground hover:text-foreground"
+                >
+                  <BookOpen className="size-4" />
+                  已 confirmed 之折讓會產生 draft 傳票 →
+                </Link>
+              </div>
               <StatusFilterBar
                 activeStatus={allowanceStatusFilter}
                 onStatusChange={handleAllowanceStatusFilterChange}

--- a/app/firm/[firmId]/client/[clientId]/voucher/[entryId]/page.tsx
+++ b/app/firm/[firmId]/client/[clientId]/voucher/[entryId]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { use, useMemo, useState } from "react";
+import { use, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { format } from "date-fns";
@@ -45,7 +45,10 @@ import {
 } from "@/components/ui/alert-dialog";
 import { cn, formatNTD } from "@/lib/utils";
 
-import { useVoucherDemoStore } from "@/lib/dev/use-voucher-demo-store";
+import {
+  seedVoucherDemoFor,
+  useVoucherDemoStore,
+} from "@/lib/dev/use-voucher-demo-store";
 import { accountLabel } from "@/lib/data/accounts";
 import { VoucherEditDialog } from "@/components/voucher-edit-dialog";
 import { VoucherReverseDialog } from "@/components/voucher-reverse-dialog";
@@ -70,6 +73,10 @@ export default function VoucherDetailPage({
   const router = useRouter();
   const store = useVoucherDemoStore();
 
+  useEffect(() => {
+    seedVoucherDemoFor(firmId, clientId);
+  }, [firmId, clientId]);
+
   const [editOpen, setEditOpen] = useState(false);
   const [reverseOpen, setReverseOpen] = useState(false);
   const [historyOpen, setHistoryOpen] = useState(false);
@@ -91,13 +98,6 @@ export default function VoucherDetailPage({
 
   const debitTotal = lines.reduce((s, l) => s + l.debit, 0);
   const creditTotal = lines.reduce((s, l) => s + l.credit, 0);
-
-  const editedCount = store.auditTrails.filter(
-    (t) =>
-      t.entity_table === "journal_entries" &&
-      t.entity_id === entryId &&
-      t.action === "updated",
-  ).length;
 
   const reverserEntry = useMemo(() => {
     if (entry?.status !== "reversed") return null;
@@ -178,14 +178,9 @@ export default function VoucherDetailPage({
                   草稿
                 </Badge>
               )}
-              {isPosted && editedCount === 0 && (
+              {isPosted && (
                 <Badge className="bg-emerald-100 text-emerald-900 hover:bg-emerald-100">
                   ✓ 已過帳
-                </Badge>
-              )}
-              {isPosted && editedCount > 0 && (
-                <Badge className="bg-amber-100 text-amber-900 hover:bg-amber-100">
-                  ✓ 已過帳・✎ 編輯 {editedCount} 次
                 </Badge>
               )}
               {isReversed && (
@@ -351,7 +346,7 @@ export default function VoucherDetailPage({
                 </Button>
               </>
             )}
-            {(editedCount > 0 || isReversed) && (
+            {!isDraft && (
               <Button variant="outline" onClick={() => setHistoryOpen(true)}>
                 <History className="size-4 mr-1" />
                 審計歷史
@@ -361,13 +356,12 @@ export default function VoucherDetailPage({
         </CardContent>
       </Card>
 
-      {editOpen && (
-        <VoucherEditDialog
-          entry={entry}
-          open={editOpen}
-          onOpenChange={setEditOpen}
-        />
-      )}
+      <VoucherEditDialog
+        entry={entry}
+        open={editOpen}
+        onOpenChange={setEditOpen}
+      />
+
       {reverseOpen && (
         <VoucherReverseDialog
           entry={entry}

--- a/app/firm/[firmId]/client/[clientId]/voucher/[entryId]/page.tsx
+++ b/app/firm/[firmId]/client/[clientId]/voucher/[entryId]/page.tsx
@@ -1,0 +1,414 @@
+"use client";
+
+import { use, useMemo, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { format } from "date-fns";
+import {
+  ArrowLeft,
+  Edit,
+  History,
+  RotateCcw,
+  Send,
+  Trash2,
+  ArrowRight,
+  ArrowLeftCircle,
+} from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { cn, formatNTD } from "@/lib/utils";
+
+import { useVoucherDemoStore } from "@/lib/dev/use-voucher-demo-store";
+import { accountLabel } from "@/lib/data/accounts";
+import { VoucherEditDialog } from "@/components/voucher-edit-dialog";
+import { VoucherReverseDialog } from "@/components/voucher-reverse-dialog";
+import { VoucherAuditHistory } from "@/components/voucher-audit-history";
+import { VoucherBatchPostDialog } from "@/components/voucher-batch-post-dialog";
+
+const DOC_TYPE_LABEL: Record<string, string> = {
+  invoice: "發票",
+  allowance: "折讓",
+  receipt: "收據",
+  payroll: "薪資單",
+  insurance: "保險費",
+  manual: "手動建單",
+};
+
+export default function VoucherDetailPage({
+  params,
+}: {
+  params: Promise<{ firmId: string; clientId: string; entryId: string }>;
+}) {
+  const { firmId, clientId, entryId } = use(params);
+  const router = useRouter();
+  const store = useVoucherDemoStore();
+
+  const [editOpen, setEditOpen] = useState(false);
+  const [reverseOpen, setReverseOpen] = useState(false);
+  const [historyOpen, setHistoryOpen] = useState(false);
+  const [postOpen, setPostOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  const entry = useMemo(
+    () => store.entries.find((e) => e.id === entryId),
+    [store.entries, entryId],
+  );
+
+  const lines = useMemo(
+    () =>
+      [...store.lines.filter((l) => l.journal_entry_id === entryId)].sort(
+        (a, b) => a.line_number - b.line_number,
+      ),
+    [store.lines, entryId],
+  );
+
+  const debitTotal = lines.reduce((s, l) => s + l.debit, 0);
+  const creditTotal = lines.reduce((s, l) => s + l.credit, 0);
+
+  const editedCount = store.auditTrails.filter(
+    (t) =>
+      t.entity_table === "journal_entries" &&
+      t.entity_id === entryId &&
+      t.action === "updated",
+  ).length;
+
+  const reverserEntry = useMemo(() => {
+    if (entry?.status !== "reversed") return null;
+    return store.entries.find((e) => e.reverses_entry_id === entryId) ?? null;
+  }, [entry?.status, store.entries, entryId]);
+
+  const reversedTarget = useMemo(() => {
+    if (!entry?.reverses_entry_id) return null;
+    return store.entries.find((e) => e.id === entry.reverses_entry_id) ?? null;
+  }, [entry?.reverses_entry_id, store.entries]);
+
+  const document = useMemo(() => {
+    if (!entry?.document_id) return null;
+    return store.documents.find((d) => d.id === entry.document_id) ?? null;
+  }, [entry?.document_id, store.documents]);
+
+  if (!entry) {
+    return (
+      <div className="space-y-4">
+        <div className="flex items-center gap-3">
+          <Button variant="ghost" size="icon" onClick={() => router.back()}>
+            <ArrowLeft className="size-4" />
+          </Button>
+          <h1 className="text-3xl font-bold tracking-tight">傳票詳情</h1>
+        </div>
+        <div className="rounded-md border border-dashed p-12 text-center text-muted-foreground text-base">
+          找不到傳票（id={entryId.slice(0, 8)}…）
+        </div>
+      </div>
+    );
+  }
+
+  const isDraft = entry.status === "draft";
+  const isPosted = entry.status === "posted";
+  const isReversed = entry.status === "reversed";
+
+  const handleDeleteDraft = () => {
+    store.deleteDraftEntry(entry.id);
+    toast.success("草稿已刪除");
+    setDeleteOpen(false);
+    router.push(`/firm/${firmId}/client/${clientId}/voucher`);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-3">
+        <Button variant="ghost" size="icon" onClick={() => router.back()}>
+          <ArrowLeft className="size-4" />
+        </Button>
+        <h1 className="text-3xl font-bold tracking-tight">傳票詳情</h1>
+        <Badge variant="outline" className="text-sm">
+          示範資料（Phase 2）
+        </Badge>
+      </div>
+
+      <Card
+        className={cn(
+          isDraft && "border-dashed bg-muted/30",
+          isReversed && "opacity-70",
+        )}
+      >
+        <CardHeader>
+          <div className="flex flex-wrap items-center gap-3 justify-between">
+            <div>
+              <CardTitle className="text-2xl font-mono">
+                {entry.voucher_no ?? "（草稿，尚未賦號）"}
+              </CardTitle>
+              <CardDescription className="text-base mt-1">
+                {entry.entry_date}・{entry.voucher_type}
+                {entry.description && (
+                  <span className="ml-2">・{entry.description}</span>
+                )}
+              </CardDescription>
+            </div>
+            <div className="flex items-center gap-2">
+              {isDraft && (
+                <Badge variant="outline" className="border-dashed">
+                  草稿
+                </Badge>
+              )}
+              {isPosted && editedCount === 0 && (
+                <Badge className="bg-emerald-100 text-emerald-900 hover:bg-emerald-100">
+                  ✓ 已過帳
+                </Badge>
+              )}
+              {isPosted && editedCount > 0 && (
+                <Badge className="bg-amber-100 text-amber-900 hover:bg-amber-100">
+                  ✓ 已過帳・✎ 編輯 {editedCount} 次
+                </Badge>
+              )}
+              {isReversed && (
+                <Badge
+                  variant="outline"
+                  className="border-destructive/50 text-destructive line-through"
+                >
+                  已沖銷
+                </Badge>
+              )}
+            </div>
+          </div>
+        </CardHeader>
+
+        <CardContent className="space-y-4">
+          {(reverserEntry || reversedTarget) && (
+            <div className="rounded-md border bg-muted/40 p-3 text-base flex items-center gap-2">
+              {reverserEntry && (
+                <>
+                  <ArrowRight className="size-4 text-muted-foreground" />
+                  <span>此傳票已被沖銷，沖銷分錄為</span>
+                  <Link
+                    href={`/firm/${firmId}/client/${clientId}/voucher/${reverserEntry.id}`}
+                    className="font-mono font-medium hover:underline"
+                  >
+                    {reverserEntry.voucher_no}
+                  </Link>
+                </>
+              )}
+              {reversedTarget && (
+                <>
+                  <ArrowLeftCircle className="size-4 text-muted-foreground" />
+                  <span>此為反向分錄，沖銷的原傳票為</span>
+                  <Link
+                    href={`/firm/${firmId}/client/${clientId}/voucher/${reversedTarget.id}`}
+                    className="font-mono font-medium hover:underline"
+                  >
+                    {reversedTarget.voucher_no}
+                  </Link>
+                </>
+              )}
+            </div>
+          )}
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-3 text-base">
+            <div>
+              <div className="text-sm text-muted-foreground">原始憑證</div>
+              <div className="mt-1">
+                {document ? (
+                  <span>
+                    {DOC_TYPE_LABEL[document.doc_type] ?? document.doc_type}
+                    ・{document.doc_date}
+                    {document.amount != null && (
+                      <span className="ml-2 font-mono">
+                        {formatNTD(document.amount)}
+                      </span>
+                    )}
+                  </span>
+                ) : (
+                  <span className="text-muted-foreground">（無原始憑證 / 系統分錄）</span>
+                )}
+              </div>
+            </div>
+            <div>
+              <div className="text-sm text-muted-foreground">過帳時間 / 人</div>
+              <div className="mt-1 font-mono">
+                {entry.posted_at ? (
+                  <>
+                    {format(entry.posted_at, "yyyy-MM-dd HH:mm")}
+                    <span className="ml-2 text-sm text-muted-foreground">
+                      {entry.posted_by ? entry.posted_by.slice(0, 8) + "…" : "系統"}
+                    </span>
+                  </>
+                ) : (
+                  <span className="text-muted-foreground font-sans">尚未過帳</span>
+                )}
+              </div>
+            </div>
+            <div>
+              <div className="text-sm text-muted-foreground">建立 / 最近更新</div>
+              <div className="mt-1 font-mono">
+                {format(entry.created_at, "yyyy-MM-dd HH:mm")} /{" "}
+                {format(entry.updated_at, "yyyy-MM-dd HH:mm")}
+              </div>
+            </div>
+          </div>
+
+          <div className="rounded-md border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-12">#</TableHead>
+                  <TableHead>科目</TableHead>
+                  <TableHead className="w-32 text-right">借方</TableHead>
+                  <TableHead className="w-32 text-right">貸方</TableHead>
+                  <TableHead>備註</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {lines.map((l) => (
+                  <TableRow key={l.id}>
+                    <TableCell className="text-muted-foreground">
+                      {l.line_number}
+                    </TableCell>
+                    <TableCell className="font-mono text-base">
+                      {accountLabel(l.account_code)}
+                    </TableCell>
+                    <TableCell className="text-right font-mono">
+                      {l.debit > 0 ? formatNTD(l.debit) : "—"}
+                    </TableCell>
+                    <TableCell className="text-right font-mono">
+                      {l.credit > 0 ? formatNTD(l.credit) : "—"}
+                    </TableCell>
+                    <TableCell className="text-base">
+                      {l.description ?? "—"}
+                    </TableCell>
+                  </TableRow>
+                ))}
+                <TableRow className="bg-muted/30 font-medium">
+                  <TableCell colSpan={2} className="text-right">合計</TableCell>
+                  <TableCell className="text-right font-mono">
+                    {formatNTD(debitTotal)}
+                  </TableCell>
+                  <TableCell className="text-right font-mono">
+                    {formatNTD(creditTotal)}
+                  </TableCell>
+                  <TableCell />
+                </TableRow>
+              </TableBody>
+            </Table>
+          </div>
+
+          <div className="flex flex-wrap gap-2 pt-2">
+            {isDraft && (
+              <>
+                <Button onClick={() => setEditOpen(true)}>
+                  <Edit className="size-4 mr-1" />
+                  編輯
+                </Button>
+                <Button onClick={() => setPostOpen(true)} variant="default">
+                  <Send className="size-4 mr-1" />
+                  過帳
+                </Button>
+                <Button
+                  variant="outline"
+                  className="text-destructive hover:text-destructive"
+                  onClick={() => setDeleteOpen(true)}
+                >
+                  <Trash2 className="size-4 mr-1" />
+                  刪除草稿
+                </Button>
+              </>
+            )}
+            {isPosted && (
+              <>
+                <Button onClick={() => setEditOpen(true)}>
+                  <Edit className="size-4 mr-1" />
+                  編輯（in-place）
+                </Button>
+                <Button variant="destructive" onClick={() => setReverseOpen(true)}>
+                  <RotateCcw className="size-4 mr-1" />
+                  沖銷
+                </Button>
+              </>
+            )}
+            {(editedCount > 0 || isReversed) && (
+              <Button variant="outline" onClick={() => setHistoryOpen(true)}>
+                <History className="size-4 mr-1" />
+                審計歷史
+              </Button>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      {editOpen && (
+        <VoucherEditDialog
+          entry={entry}
+          open={editOpen}
+          onOpenChange={setEditOpen}
+        />
+      )}
+      {reverseOpen && (
+        <VoucherReverseDialog
+          entry={entry}
+          open={reverseOpen}
+          onOpenChange={setReverseOpen}
+        />
+      )}
+      {historyOpen && (
+        <VoucherAuditHistory
+          entryId={entry.id}
+          open={historyOpen}
+          onOpenChange={setHistoryOpen}
+        />
+      )}
+      {postOpen && (
+        <VoucherBatchPostDialog
+          entries={[entry]}
+          open={postOpen}
+          onOpenChange={setPostOpen}
+        />
+      )}
+
+      <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>刪除草稿？</AlertDialogTitle>
+            <AlertDialogDescription className="text-base">
+              草稿尚未進入帳本，刪除後將無法復原。
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>保留草稿</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDeleteDraft}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              確認刪除
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/app/firm/[firmId]/client/[clientId]/voucher/page.tsx
+++ b/app/firm/[firmId]/client/[clientId]/voucher/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { use, useMemo, useState } from "react";
+import { use, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { format } from "date-fns";
 import { ArrowLeft, CalendarIcon, Filter, X } from "lucide-react";
@@ -35,47 +35,36 @@ import { Badge } from "@/components/ui/badge";
 import { TablePagination } from "@/components/table-pagination";
 import { cn, formatNTD } from "@/lib/utils";
 
-import { useVoucherDemoStore } from "@/lib/dev/use-voucher-demo-store";
-import type { JournalEntry } from "@/lib/domain/journal-entry";
+import {
+  seedVoucherDemoFor,
+  useVoucherDemoStore,
+} from "@/lib/dev/use-voucher-demo-store";
+import {
+  buildLineSumsMap,
+  type JournalEntry,
+} from "@/lib/domain/journal-entry";
 import { VoucherBatchPostDialog } from "@/components/voucher-batch-post-dialog";
 
-type StatusFilter = "all" | "draft" | "posted" | "edited" | "reversed";
+type StatusFilter = "all" | "draft" | "posted" | "reversed";
 
 const STATUS_TABS: { key: StatusFilter; label: string }[] = [
   { key: "all", label: "全部" },
   { key: "draft", label: "草稿" },
   { key: "posted", label: "已過帳" },
-  { key: "edited", label: "已編輯" },
   { key: "reversed", label: "已沖銷" },
 ];
 
 const PAGE_SIZE = 25;
 
-function statusKey(
-  entry: JournalEntry,
-  editedSet: Set<string>,
-): "draft" | "posted" | "edited" | "reversed" {
-  if (entry.status === "draft") return "draft";
-  if (entry.status === "reversed") return "reversed";
-  return editedSet.has(entry.id) ? "edited" : "posted";
-}
-
-function StatusBadge({
-  entry,
-  editedSet,
-}: {
-  entry: JournalEntry;
-  editedSet: Set<string>;
-}) {
-  const k = statusKey(entry, editedSet);
-  if (k === "draft") {
+function StatusBadge({ entry }: { entry: JournalEntry }) {
+  if (entry.status === "draft") {
     return (
       <Badge variant="outline" className="border-dashed text-muted-foreground">
         草稿
       </Badge>
     );
   }
-  if (k === "reversed") {
+  if (entry.status === "reversed") {
     return (
       <Badge
         variant="outline"
@@ -85,33 +74,11 @@ function StatusBadge({
       </Badge>
     );
   }
-  if (k === "edited") {
-    return (
-      <Badge className="bg-amber-100 text-amber-900 hover:bg-amber-100">
-        ✓ 已過帳・✎ 編輯
-      </Badge>
-    );
-  }
   return (
     <Badge className="bg-emerald-100 text-emerald-900 hover:bg-emerald-100">
       ✓ 已過帳
     </Badge>
   );
-}
-
-function lineSums(
-  entryId: string,
-  lines: { journal_entry_id: string; debit: number; credit: number }[],
-) {
-  let debit = 0;
-  let credit = 0;
-  for (const l of lines) {
-    if (l.journal_entry_id === entryId) {
-      debit += l.debit;
-      credit += l.credit;
-    }
-  }
-  return { debit, credit };
 }
 
 export default function VoucherListPage({
@@ -123,6 +90,10 @@ export default function VoucherListPage({
   const router = useRouter();
   const store = useVoucherDemoStore();
 
+  useEffect(() => {
+    seedVoucherDemoFor(firmId, clientId);
+  }, [firmId, clientId]);
+
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
   const [docTypeFilter, setDocTypeFilter] = useState<string>("all");
   const [dateFrom, setDateFrom] = useState<string>("");
@@ -132,35 +103,33 @@ export default function VoucherListPage({
   const [page, setPage] = useState(0);
   const [batchOpen, setBatchOpen] = useState(false);
 
-  const editedSet = useMemo(() => {
-    const s = new Set<string>();
-    for (const t of store.auditTrails) {
-      if (t.entity_table === "journal_entries" && t.action === "updated") {
-        s.add(t.entity_id);
-      }
-    }
-    return s;
-  }, [store.auditTrails]);
+  const documentsById = useMemo(
+    () => new Map(store.documents.map((d) => [d.id, d] as const)),
+    [store.documents],
+  );
 
-  const documentsById = useMemo(() => {
-    const m = new Map(store.documents.map((d) => [d.id, d] as const));
-    return m;
-  }, [store.documents]);
+  const clientEntries = useMemo(
+    () => store.entries.filter((e) => e.client_id === clientId),
+    [store.entries, clientId],
+  );
+
+  const lineSumsByEntry = useMemo(() => {
+    const ids = new Set(clientEntries.map((e) => e.id));
+    return buildLineSumsMap(store.lines.filter((l) => ids.has(l.journal_entry_id)));
+  }, [clientEntries, store.lines]);
 
   const { counts, filtered } = useMemo(() => {
     const c: Record<StatusFilter, number> = {
-      all: store.entries.length,
+      all: clientEntries.length,
       draft: 0,
       posted: 0,
-      edited: 0,
       reversed: 0,
     };
     const kw = keyword.trim();
     const list: JournalEntry[] = [];
-    for (const e of store.entries) {
-      const k = statusKey(e, editedSet);
-      c[k] += 1;
-      if (statusFilter !== "all" && k !== statusFilter) continue;
+    for (const e of clientEntries) {
+      c[e.status] += 1;
+      if (statusFilter !== "all" && e.status !== statusFilter) continue;
       if (dateFrom && e.entry_date < dateFrom) continue;
       if (dateTo && e.entry_date > dateTo) continue;
       if (docTypeFilter !== "all") {
@@ -185,7 +154,7 @@ export default function VoucherListPage({
       return b.created_at.getTime() - a.created_at.getTime();
     });
     return { counts: c, filtered: list };
-  }, [store.entries, statusFilter, dateFrom, dateTo, docTypeFilter, keyword, editedSet, documentsById]);
+  }, [clientEntries, statusFilter, dateFrom, dateTo, docTypeFilter, keyword, documentsById]);
 
   const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
   const safePage = Math.min(page, totalPages - 1);
@@ -230,8 +199,8 @@ export default function VoucherListPage({
   };
 
   const selectedEntries = useMemo(
-    () => store.entries.filter((e) => selected.has(e.id)),
-    [store.entries, selected],
+    () => clientEntries.filter((e) => selected.has(e.id)),
+    [clientEntries, selected],
   );
 
   return (
@@ -410,30 +379,30 @@ export default function VoucherListPage({
                     aria-label="全選"
                   />
                 </TableHead>
-                <TableHead className="w-40">傳票編號 / 日期</TableHead>
-                <TableHead className="w-24">類型</TableHead>
+                <TableHead className="w-28">日期</TableHead>
+                <TableHead className="w-36">傳票編號</TableHead>
+                <TableHead className="w-20">類型</TableHead>
                 <TableHead>摘要</TableHead>
-                <TableHead className="w-32 text-right">借 / 貸</TableHead>
-                <TableHead className="w-32">狀態</TableHead>
+                <TableHead className="w-36 text-right">借 / 貸</TableHead>
+                <TableHead className="w-24">狀態</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
               {pageRows.length === 0 ? (
                 <TableRow>
-                  <TableCell colSpan={6} className="text-center py-12 text-muted-foreground text-base">
+                  <TableCell colSpan={7} className="text-center py-12 text-muted-foreground text-base">
                     尚無符合條件的傳票
                   </TableCell>
                 </TableRow>
               ) : (
                 pageRows.map((entry) => {
-                  const sums = lineSums(entry.id, store.lines);
-                  const k = statusKey(entry, editedSet);
+                  const sums = lineSumsByEntry.get(entry.id) ?? { debit: 0, credit: 0 };
                   return (
                     <TableRow
                       key={entry.id}
                       className={cn(
-                        k === "draft" && "bg-muted/30",
-                        k === "reversed" && "opacity-60",
+                        entry.status === "draft" && "bg-muted/30",
+                        entry.status === "reversed" && "opacity-60",
                       )}
                     >
                       <TableCell>
@@ -447,22 +416,27 @@ export default function VoucherListPage({
                           <span className="block w-4" />
                         )}
                       </TableCell>
-                      <TableCell>
+                      <TableCell className="font-mono text-base">
                         <Link
                           href={`/firm/${firmId}/client/${clientId}/voucher/${entry.id}`}
-                          className="block"
+                          className="block hover:underline"
                         >
-                          <div className="font-mono text-base font-medium">
-                            {entry.voucher_no ?? "（無編號）"}
-                          </div>
-                          <div className="text-sm text-muted-foreground">
-                            {entry.entry_date}
-                          </div>
+                          {entry.entry_date}
+                        </Link>
+                      </TableCell>
+                      <TableCell className="font-mono text-base font-medium">
+                        <Link
+                          href={`/firm/${firmId}/client/${clientId}/voucher/${entry.id}`}
+                          className="block hover:underline"
+                        >
+                          {entry.voucher_no ?? "（無編號）"}
                         </Link>
                       </TableCell>
                       <TableCell className="text-base">{entry.voucher_type}</TableCell>
-                      <TableCell className="text-base max-w-[420px] truncate">
-                        {entry.description ?? "—"}
+                      <TableCell className="text-base max-w-[420px]">
+                        <div className="line-clamp-2">
+                          {entry.description ?? "—"}
+                        </div>
                       </TableCell>
                       <TableCell className="text-right font-mono text-base">
                         {formatNTD(sums.debit)}
@@ -470,7 +444,7 @@ export default function VoucherListPage({
                         {formatNTD(sums.credit)}
                       </TableCell>
                       <TableCell>
-                        <StatusBadge entry={entry} editedSet={editedSet} />
+                        <StatusBadge entry={entry} />
                       </TableCell>
                     </TableRow>
                   );

--- a/app/firm/[firmId]/client/[clientId]/voucher/page.tsx
+++ b/app/firm/[firmId]/client/[clientId]/voucher/page.tsx
@@ -1,0 +1,502 @@
+"use client";
+
+import { use, useMemo, useState } from "react";
+import Link from "next/link";
+import { format } from "date-fns";
+import { ArrowLeft, CalendarIcon, Filter, X } from "lucide-react";
+import { useRouter } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Calendar } from "@/components/ui/calendar";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Badge } from "@/components/ui/badge";
+import { TablePagination } from "@/components/table-pagination";
+import { cn, formatNTD } from "@/lib/utils";
+
+import { useVoucherDemoStore } from "@/lib/dev/use-voucher-demo-store";
+import type { JournalEntry } from "@/lib/domain/journal-entry";
+import { VoucherBatchPostDialog } from "@/components/voucher-batch-post-dialog";
+
+type StatusFilter = "all" | "draft" | "posted" | "edited" | "reversed";
+
+const STATUS_TABS: { key: StatusFilter; label: string }[] = [
+  { key: "all", label: "全部" },
+  { key: "draft", label: "草稿" },
+  { key: "posted", label: "已過帳" },
+  { key: "edited", label: "已編輯" },
+  { key: "reversed", label: "已沖銷" },
+];
+
+const PAGE_SIZE = 25;
+
+function statusKey(
+  entry: JournalEntry,
+  editedSet: Set<string>,
+): "draft" | "posted" | "edited" | "reversed" {
+  if (entry.status === "draft") return "draft";
+  if (entry.status === "reversed") return "reversed";
+  return editedSet.has(entry.id) ? "edited" : "posted";
+}
+
+function StatusBadge({
+  entry,
+  editedSet,
+}: {
+  entry: JournalEntry;
+  editedSet: Set<string>;
+}) {
+  const k = statusKey(entry, editedSet);
+  if (k === "draft") {
+    return (
+      <Badge variant="outline" className="border-dashed text-muted-foreground">
+        草稿
+      </Badge>
+    );
+  }
+  if (k === "reversed") {
+    return (
+      <Badge
+        variant="outline"
+        className="border-destructive/50 text-destructive line-through"
+      >
+        已沖銷
+      </Badge>
+    );
+  }
+  if (k === "edited") {
+    return (
+      <Badge className="bg-amber-100 text-amber-900 hover:bg-amber-100">
+        ✓ 已過帳・✎ 編輯
+      </Badge>
+    );
+  }
+  return (
+    <Badge className="bg-emerald-100 text-emerald-900 hover:bg-emerald-100">
+      ✓ 已過帳
+    </Badge>
+  );
+}
+
+function lineSums(
+  entryId: string,
+  lines: { journal_entry_id: string; debit: number; credit: number }[],
+) {
+  let debit = 0;
+  let credit = 0;
+  for (const l of lines) {
+    if (l.journal_entry_id === entryId) {
+      debit += l.debit;
+      credit += l.credit;
+    }
+  }
+  return { debit, credit };
+}
+
+export default function VoucherListPage({
+  params,
+}: {
+  params: Promise<{ firmId: string; clientId: string }>;
+}) {
+  const { firmId, clientId } = use(params);
+  const router = useRouter();
+  const store = useVoucherDemoStore();
+
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
+  const [docTypeFilter, setDocTypeFilter] = useState<string>("all");
+  const [dateFrom, setDateFrom] = useState<string>("");
+  const [dateTo, setDateTo] = useState<string>("");
+  const [keyword, setKeyword] = useState("");
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [page, setPage] = useState(0);
+  const [batchOpen, setBatchOpen] = useState(false);
+
+  const editedSet = useMemo(() => {
+    const s = new Set<string>();
+    for (const t of store.auditTrails) {
+      if (t.entity_table === "journal_entries" && t.action === "updated") {
+        s.add(t.entity_id);
+      }
+    }
+    return s;
+  }, [store.auditTrails]);
+
+  const documentsById = useMemo(() => {
+    const m = new Map(store.documents.map((d) => [d.id, d] as const));
+    return m;
+  }, [store.documents]);
+
+  const { counts, filtered } = useMemo(() => {
+    const c: Record<StatusFilter, number> = {
+      all: store.entries.length,
+      draft: 0,
+      posted: 0,
+      edited: 0,
+      reversed: 0,
+    };
+    const kw = keyword.trim();
+    const list: JournalEntry[] = [];
+    for (const e of store.entries) {
+      const k = statusKey(e, editedSet);
+      c[k] += 1;
+      if (statusFilter !== "all" && k !== statusFilter) continue;
+      if (dateFrom && e.entry_date < dateFrom) continue;
+      if (dateTo && e.entry_date > dateTo) continue;
+      if (docTypeFilter !== "all") {
+        if (docTypeFilter === "system") {
+          if (e.document_id != null) continue;
+        } else {
+          const doc = e.document_id ? documentsById.get(e.document_id) : null;
+          if (doc?.doc_type !== docTypeFilter) continue;
+        }
+      }
+      if (kw) {
+        const matches =
+          (e.voucher_no?.includes(kw) ?? false) ||
+          (e.description?.includes(kw) ?? false);
+        if (!matches) continue;
+      }
+      list.push(e);
+    }
+    list.sort((a, b) => {
+      if (a.entry_date !== b.entry_date)
+        return b.entry_date.localeCompare(a.entry_date);
+      return b.created_at.getTime() - a.created_at.getTime();
+    });
+    return { counts: c, filtered: list };
+  }, [store.entries, statusFilter, dateFrom, dateTo, docTypeFilter, keyword, editedSet, documentsById]);
+
+  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  const safePage = Math.min(page, totalPages - 1);
+  const pageRows = filtered.slice(safePage * PAGE_SIZE, (safePage + 1) * PAGE_SIZE);
+
+  const visibleDraftIds = useMemo(
+    () => pageRows.filter((e) => e.status === "draft").map((e) => e.id),
+    [pageRows],
+  );
+  const allSelected =
+    visibleDraftIds.length > 0 && visibleDraftIds.every((id) => selected.has(id));
+  const someSelected = visibleDraftIds.some((id) => selected.has(id));
+
+  const toggleAll = () => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (allSelected) {
+        for (const id of visibleDraftIds) next.delete(id);
+      } else {
+        for (const id of visibleDraftIds) next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const toggleOne = (id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const clearFilters = () => {
+    setStatusFilter("all");
+    setDocTypeFilter("all");
+    setDateFrom("");
+    setDateTo("");
+    setKeyword("");
+    setPage(0);
+  };
+
+  const selectedEntries = useMemo(
+    () => store.entries.filter((e) => selected.has(e.id)),
+    [store.entries, selected],
+  );
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-3">
+        <Button variant="ghost" size="icon" onClick={() => router.back()}>
+          <ArrowLeft className="size-4" />
+        </Button>
+        <h1 className="text-3xl font-bold tracking-tight">傳票管理</h1>
+        <Badge variant="outline" className="text-sm">
+          示範資料（Phase 2）
+        </Badge>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Filter className="size-4" />
+            篩選與批次操作
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex flex-wrap gap-2">
+            {STATUS_TABS.map((tab) => (
+              <Button
+                key={tab.key}
+                size="sm"
+                variant={statusFilter === tab.key ? "default" : "outline"}
+                onClick={() => {
+                  setStatusFilter(tab.key);
+                  setPage(0);
+                }}
+              >
+                {tab.label}
+                <span className="ml-2 text-sm opacity-70">{counts[tab.key]}</span>
+              </Button>
+            ))}
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
+            <div>
+              <label className="text-sm text-muted-foreground">日期起</label>
+              <Popover>
+                <PopoverTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className={cn(
+                      "w-full justify-start font-normal mt-1",
+                      !dateFrom && "text-muted-foreground",
+                    )}
+                  >
+                    <CalendarIcon className="mr-2 size-4" />
+                    {dateFrom || "（全部）"}
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className="w-auto p-0" align="start">
+                  <Calendar
+                    mode="single"
+                    selected={dateFrom ? new Date(dateFrom) : undefined}
+                    onSelect={(d) => {
+                      setDateFrom(d ? format(d, "yyyy-MM-dd") : "");
+                      setPage(0);
+                    }}
+                    autoFocus
+                  />
+                </PopoverContent>
+              </Popover>
+            </div>
+            <div>
+              <label className="text-sm text-muted-foreground">日期迄</label>
+              <Popover>
+                <PopoverTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className={cn(
+                      "w-full justify-start font-normal mt-1",
+                      !dateTo && "text-muted-foreground",
+                    )}
+                  >
+                    <CalendarIcon className="mr-2 size-4" />
+                    {dateTo || "（全部）"}
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className="w-auto p-0" align="start">
+                  <Calendar
+                    mode="single"
+                    selected={dateTo ? new Date(dateTo) : undefined}
+                    onSelect={(d) => {
+                      setDateTo(d ? format(d, "yyyy-MM-dd") : "");
+                      setPage(0);
+                    }}
+                    autoFocus
+                  />
+                </PopoverContent>
+              </Popover>
+            </div>
+            <div>
+              <label className="text-sm text-muted-foreground">文件類型</label>
+              <Select
+                value={docTypeFilter}
+                onValueChange={(v) => {
+                  setDocTypeFilter(v);
+                  setPage(0);
+                }}
+              >
+                <SelectTrigger className="mt-1">
+                  <SelectValue placeholder="全部" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">全部</SelectItem>
+                  <SelectItem value="invoice">發票</SelectItem>
+                  <SelectItem value="allowance">折讓</SelectItem>
+                  <SelectItem value="system">系統分錄（無原始憑證）</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <label className="text-sm text-muted-foreground">關鍵字</label>
+              <Input
+                value={keyword}
+                onChange={(e) => {
+                  setKeyword(e.target.value);
+                  setPage(0);
+                }}
+                placeholder="傳票編號或摘要"
+                className="mt-1"
+              />
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between">
+            <div className="text-base text-muted-foreground">
+              共 {filtered.length} 筆
+              {selected.size > 0 && (
+                <span className="ml-2">・已選取 {selected.size} 筆</span>
+              )}
+            </div>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={clearFilters}
+                disabled={
+                  statusFilter === "all" &&
+                  docTypeFilter === "all" &&
+                  !dateFrom &&
+                  !dateTo &&
+                  !keyword
+                }
+              >
+                <X className="size-4 mr-1" />
+                清除篩選
+              </Button>
+              <Button
+                onClick={() => setBatchOpen(true)}
+                disabled={selectedEntries.filter((e) => e.status === "draft").length === 0}
+              >
+                批次過帳（{selectedEntries.filter((e) => e.status === "draft").length}）
+              </Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="p-0">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-10">
+                  <Checkbox
+                    checked={allSelected ? true : someSelected ? "indeterminate" : false}
+                    onCheckedChange={toggleAll}
+                    aria-label="全選"
+                  />
+                </TableHead>
+                <TableHead className="w-40">傳票編號 / 日期</TableHead>
+                <TableHead className="w-24">類型</TableHead>
+                <TableHead>摘要</TableHead>
+                <TableHead className="w-32 text-right">借 / 貸</TableHead>
+                <TableHead className="w-32">狀態</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {pageRows.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={6} className="text-center py-12 text-muted-foreground text-base">
+                    尚無符合條件的傳票
+                  </TableCell>
+                </TableRow>
+              ) : (
+                pageRows.map((entry) => {
+                  const sums = lineSums(entry.id, store.lines);
+                  const k = statusKey(entry, editedSet);
+                  return (
+                    <TableRow
+                      key={entry.id}
+                      className={cn(
+                        k === "draft" && "bg-muted/30",
+                        k === "reversed" && "opacity-60",
+                      )}
+                    >
+                      <TableCell>
+                        {entry.status === "draft" ? (
+                          <Checkbox
+                            checked={selected.has(entry.id)}
+                            onCheckedChange={() => toggleOne(entry.id)}
+                            aria-label="選取"
+                          />
+                        ) : (
+                          <span className="block w-4" />
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        <Link
+                          href={`/firm/${firmId}/client/${clientId}/voucher/${entry.id}`}
+                          className="block"
+                        >
+                          <div className="font-mono text-base font-medium">
+                            {entry.voucher_no ?? "（無編號）"}
+                          </div>
+                          <div className="text-sm text-muted-foreground">
+                            {entry.entry_date}
+                          </div>
+                        </Link>
+                      </TableCell>
+                      <TableCell className="text-base">{entry.voucher_type}</TableCell>
+                      <TableCell className="text-base max-w-[420px] truncate">
+                        {entry.description ?? "—"}
+                      </TableCell>
+                      <TableCell className="text-right font-mono text-base">
+                        {formatNTD(sums.debit)}
+                        <span className="mx-1 text-muted-foreground">/</span>
+                        {formatNTD(sums.credit)}
+                      </TableCell>
+                      <TableCell>
+                        <StatusBadge entry={entry} editedSet={editedSet} />
+                      </TableCell>
+                    </TableRow>
+                  );
+                })
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+
+      <TablePagination
+        page={safePage}
+        totalPages={totalPages}
+        totalItems={filtered.length}
+        pageSize={PAGE_SIZE}
+        onPageChange={setPage}
+      />
+
+      {batchOpen && (
+        <VoucherBatchPostDialog
+          entries={selectedEntries}
+          open={batchOpen}
+          onOpenChange={setBatchOpen}
+          onPosted={() => setSelected(new Set())}
+        />
+      )}
+    </div>
+  );
+}

--- a/components/firm-sidebar.tsx
+++ b/components/firm-sidebar.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { 
-  LayoutDashboard, 
-  Users, 
-  FileText, 
+import {
+  LayoutDashboard,
+  Users,
+  FileText,
   Settings,
-  LogOut
+  LogOut,
+  BookOpen,
 } from "lucide-react";
 import {
   Sidebar,
@@ -27,7 +28,8 @@ import { createClient } from "@/lib/supabase/client";
 export function FirmSidebar() {
   const router = useRouter();
   const supabase = createClient();
-  const { firmId } = useParams() as { firmId: string };
+  const params = useParams() as { firmId: string; clientId?: string };
+  const { firmId, clientId } = params;
 
   const handleLogout = async () => {
     await supabase.auth.signOut();
@@ -40,6 +42,17 @@ export function FirmSidebar() {
     { title: "發票管理", url: `/firm/${firmId}/invoice`, icon: FileText },
     { title: "設定", url: `/firm/${firmId}/settings`, icon: Settings },
   ];
+
+  // 客戶子模組：僅在 URL 含 clientId 時顯示。
+  const clientItems = clientId
+    ? [
+        {
+          title: "傳票",
+          url: `/firm/${firmId}/client/${clientId}/voucher`,
+          icon: BookOpen,
+        },
+      ]
+    : [];
 
   return (
     <Sidebar collapsible="icon">
@@ -77,6 +90,25 @@ export function FirmSidebar() {
             </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>
+        {clientItems.length > 0 && (
+          <SidebarGroup>
+            <SidebarGroupLabel className="text-sm">客戶子模組</SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                {clientItems.map((item) => (
+                  <SidebarMenuItem key={item.title}>
+                    <SidebarMenuButton asChild tooltip={item.title} className="text-base">
+                      <Link href={item.url}>
+                        <item.icon />
+                        <span>{item.title}</span>
+                      </Link>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                ))}
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        )}
       </SidebarContent>
       <SidebarFooter>
         <SidebarMenu>

--- a/components/voucher-audit-history.tsx
+++ b/components/voucher-audit-history.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { History } from "lucide-react";
+import { format } from "date-fns";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+import { useVoucherDemoStore } from "@/lib/dev/use-voucher-demo-store";
+import type { AuditAction } from "@/lib/domain/audit-trail";
+import { accountLabel } from "@/lib/data/accounts";
+import { formatNTD } from "@/lib/utils";
+
+interface VoucherAuditHistoryProps {
+  entryId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const ACTION_LABEL: Record<AuditAction, string> = {
+  created: "建立",
+  updated: "編輯",
+  deleted: "刪除",
+  posted: "過帳",
+  voided: "作廢",
+  marked_duplicate: "標記重複",
+  reversed: "被沖銷",
+};
+
+interface BeforeSnapshot {
+  entry?: {
+    voucher_type?: string;
+    entry_date?: string;
+    description?: string | null;
+  };
+  lines?: {
+    line_number: number;
+    account_code: string;
+    debit: number;
+    credit: number;
+    description?: string | null;
+  }[];
+}
+
+function isBeforeSnapshot(value: unknown): value is BeforeSnapshot {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    ("entry" in value || "lines" in value)
+  );
+}
+
+export function VoucherAuditHistory({
+  entryId,
+  open,
+  onOpenChange,
+}: VoucherAuditHistoryProps) {
+  const store = useVoucherDemoStore();
+  const trails = [...store.auditTrails]
+    .filter((t) => t.entity_table === "journal_entries" && t.entity_id === entryId)
+    .sort((a, b) => b.actor_at.getTime() - a.actor_at.getTime());
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-3xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <History className="size-5" />
+            審計歷史
+          </DialogTitle>
+          <DialogDescription className="text-base">
+            此傳票的所有變更紀錄（最新在上）。
+          </DialogDescription>
+        </DialogHeader>
+
+        {trails.length === 0 ? (
+          <div className="rounded-md border border-dashed p-6 text-center text-base text-muted-foreground">
+            目前沒有審計紀錄。
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {trails.map((t) => (
+              <div key={t.id} className="rounded-md border p-3 space-y-2">
+                <div className="flex items-center justify-between text-base">
+                  <div className="font-medium">
+                    {ACTION_LABEL[t.action] ?? t.action}
+                  </div>
+                  <div className="text-sm text-muted-foreground font-mono">
+                    {format(t.actor_at, "yyyy-MM-dd HH:mm:ss")}
+                  </div>
+                </div>
+                {t.reason && (
+                  <div className="text-base">
+                    <span className="text-muted-foreground">原因：</span>
+                    {t.reason}
+                  </div>
+                )}
+                <div className="text-sm text-muted-foreground">
+                  操作者：
+                  {t.actor_id ? (
+                    <span className="font-mono">{t.actor_id.slice(0, 8)}…</span>
+                  ) : (
+                    "系統"
+                  )}
+                </div>
+                {isBeforeSnapshot(t.before) && t.before.lines && (
+                  <div>
+                    <div className="text-sm text-muted-foreground mb-1">
+                      變更前的分錄：
+                    </div>
+                    <div className="rounded border bg-muted/30">
+                      <Table>
+                        <TableHeader>
+                          <TableRow>
+                            <TableHead className="w-12">#</TableHead>
+                            <TableHead>科目</TableHead>
+                            <TableHead className="text-right">借方</TableHead>
+                            <TableHead className="text-right">貸方</TableHead>
+                            <TableHead>備註</TableHead>
+                          </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                          {t.before.lines.map((l) => (
+                            <TableRow key={l.line_number}>
+                              <TableCell>{l.line_number}</TableCell>
+                              <TableCell className="font-mono text-base">
+                                {accountLabel(l.account_code)}
+                              </TableCell>
+                              <TableCell className="text-right font-mono">
+                                {l.debit > 0 ? formatNTD(l.debit) : "—"}
+                              </TableCell>
+                              <TableCell className="text-right font-mono">
+                                {l.credit > 0 ? formatNTD(l.credit) : "—"}
+                              </TableCell>
+                              <TableCell className="text-base">
+                                {l.description ?? "—"}
+                              </TableCell>
+                            </TableRow>
+                          ))}
+                        </TableBody>
+                      </Table>
+                    </div>
+                    {t.before.entry?.description && (
+                      <div className="text-sm text-muted-foreground mt-1">
+                        變更前摘要：{t.before.entry.description}
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+
+        <div className="flex justify-end pt-2">
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            關閉
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/voucher-audit-history.tsx
+++ b/components/voucher-audit-history.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useMemo } from "react";
 import { History } from "lucide-react";
 import { format } from "date-fns";
 
@@ -41,38 +42,19 @@ const ACTION_LABEL: Record<AuditAction, string> = {
   reversed: "被沖銷",
 };
 
-interface BeforeSnapshot {
-  entry?: {
-    voucher_type?: string;
-    entry_date?: string;
-    description?: string | null;
-  };
-  lines?: {
-    line_number: number;
-    account_code: string;
-    debit: number;
-    credit: number;
-    description?: string | null;
-  }[];
-}
-
-function isBeforeSnapshot(value: unknown): value is BeforeSnapshot {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    ("entry" in value || "lines" in value)
-  );
-}
-
 export function VoucherAuditHistory({
   entryId,
   open,
   onOpenChange,
 }: VoucherAuditHistoryProps) {
   const store = useVoucherDemoStore();
-  const trails = [...store.auditTrails]
-    .filter((t) => t.entity_table === "journal_entries" && t.entity_id === entryId)
-    .sort((a, b) => b.actor_at.getTime() - a.actor_at.getTime());
+  const trails = useMemo(
+    () =>
+      store.auditTrails
+        .filter((t) => t.entity_table === "journal_entries" && t.entity_id === entryId)
+        .sort((a, b) => b.actor_at.getTime() - a.actor_at.getTime()),
+    [store.auditTrails, entryId],
+  );
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -117,7 +99,7 @@ export function VoucherAuditHistory({
                     "系統"
                   )}
                 </div>
-                {isBeforeSnapshot(t.before) && t.before.lines && (
+                {t.before?.lines && (
                   <div>
                     <div className="text-sm text-muted-foreground mb-1">
                       變更前的分錄：

--- a/components/voucher-batch-post-dialog.tsx
+++ b/components/voucher-batch-post-dialog.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import { useState } from "react";
+import { CheckCircle2, XCircle, AlertCircle } from "lucide-react";
+import { toast } from "sonner";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { cn, formatNTD } from "@/lib/utils";
+
+import type { JournalEntry } from "@/lib/domain/journal-entry";
+import { useVoucherDemoStore } from "@/lib/dev/use-voucher-demo-store";
+
+interface VoucherBatchPostDialogProps {
+  entries: JournalEntry[];
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onPosted?: () => void;
+}
+
+interface PostResult {
+  entry_id: string;
+  voucher_no: string | null;
+  error: string | null;
+}
+
+function summarizeEntry(
+  entry: JournalEntry,
+  allLines: { journal_entry_id: string; debit: number; credit: number }[],
+): { debit: number; credit: number; balanced: boolean } {
+  const ls = allLines.filter((l) => l.journal_entry_id === entry.id);
+  const debit = ls.reduce((s, l) => s + l.debit, 0);
+  const credit = ls.reduce((s, l) => s + l.credit, 0);
+  return { debit, credit, balanced: debit === credit && debit > 0 };
+}
+
+export function VoucherBatchPostDialog({
+  entries,
+  open,
+  onOpenChange,
+  onPosted,
+}: VoucherBatchPostDialogProps) {
+  const store = useVoucherDemoStore();
+  const [reviewed, setReviewed] = useState(false);
+  const [results, setResults] = useState<PostResult[] | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const drafts = entries.filter((e) => e.status === "draft");
+  const summaries = drafts.map((e) => ({
+    entry: e,
+    ...summarizeEntry(e, store.lines),
+  }));
+  const balancedCount = summaries.filter((s) => s.balanced).length;
+
+  const handleSubmit = () => {
+    if (!reviewed || drafts.length === 0) return;
+    setSubmitting(true);
+    const ids = drafts.map((e) => e.id);
+    const res = store.postEntries(ids, store.userId);
+    setResults(res);
+    const successCount = res.filter((r) => !r.error).length;
+    const failCount = res.length - successCount;
+    if (failCount === 0) {
+      toast.success(`成功過帳 ${successCount} 筆`);
+    } else {
+      toast.warning(`成功 ${successCount} 筆、失敗 ${failCount} 筆`);
+    }
+    setSubmitting(false);
+    onPosted?.();
+  };
+
+  const handleClose = () => {
+    setReviewed(false);
+    setResults(null);
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => (v ? onOpenChange(v) : handleClose())}>
+      <DialogContent className="max-w-3xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>批次過帳</DialogTitle>
+          <DialogDescription className="text-base">
+            {results
+              ? "過帳結果如下，請逐筆確認。"
+              : `將為以下 ${drafts.length} 筆草稿賦予傳票編號並進入帳本。過帳後不可直接刪除，當年度未關帳前可 in-place edit（需填修改原因）；跨年度後不可改。`}
+          </DialogDescription>
+        </DialogHeader>
+
+        {!results && drafts.length > 0 && (
+          <div className="rounded-md border border-amber-300 bg-amber-50 p-3 text-base text-amber-900 flex gap-2 items-start">
+            <AlertCircle className="size-5 shrink-0 mt-0.5" />
+            <div>
+              其中 <strong>{balancedCount}</strong> 筆借貸平衡可成功過帳；
+              <strong>{drafts.length - balancedCount}</strong> 筆不平衡將被略過（不消耗傳票編號）。
+            </div>
+          </div>
+        )}
+
+        <div className="rounded-md border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>日期</TableHead>
+                <TableHead>類型</TableHead>
+                <TableHead>摘要</TableHead>
+                <TableHead className="text-right">借 / 貸</TableHead>
+                <TableHead className="w-32">結果</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {summaries.map((s) => {
+                const r = results?.find((x) => x.entry_id === s.entry.id);
+                return (
+                  <TableRow key={s.entry.id}>
+                    <TableCell className="font-mono text-base">
+                      {s.entry.entry_date}
+                    </TableCell>
+                    <TableCell className="text-base">
+                      {s.entry.voucher_type}
+                    </TableCell>
+                    <TableCell className="text-base max-w-[280px] truncate">
+                      {s.entry.description ?? "—"}
+                    </TableCell>
+                    <TableCell className="text-right font-mono text-base">
+                      {formatNTD(s.debit)} / {formatNTD(s.credit)}
+                    </TableCell>
+                    <TableCell>
+                      {r ? (
+                        r.error ? (
+                          <span className="inline-flex items-center gap-1 text-destructive text-base">
+                            <XCircle className="size-4" />
+                            {r.error}
+                          </span>
+                        ) : (
+                          <span className="inline-flex items-center gap-1 text-emerald-700 text-base font-mono">
+                            <CheckCircle2 className="size-4" />
+                            {r.voucher_no}
+                          </span>
+                        )
+                      ) : (
+                        <span
+                          className={cn(
+                            "text-sm",
+                            s.balanced ? "text-emerald-700" : "text-destructive",
+                          )}
+                        >
+                          {s.balanced ? "可過帳" : "不平衡"}
+                        </span>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </div>
+
+        {!results && (
+          <label className="flex items-start gap-2 cursor-pointer">
+            <Checkbox
+              checked={reviewed}
+              onCheckedChange={(v) => setReviewed(Boolean(v))}
+              className="mt-0.5"
+            />
+            <span className="text-base">
+              我已逐筆檢查過所有選取的傳票（科目、金額、日期皆正確）。
+            </span>
+          </label>
+        )}
+
+        <DialogFooter>
+          {results ? (
+            <Button onClick={handleClose}>關閉</Button>
+          ) : (
+            <>
+              <Button variant="outline" onClick={handleClose}>
+                取消
+              </Button>
+              <Button
+                onClick={handleSubmit}
+                disabled={!reviewed || drafts.length === 0 || submitting}
+              >
+                確認過帳
+              </Button>
+            </>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/voucher-batch-post-dialog.tsx
+++ b/components/voucher-batch-post-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { CheckCircle2, XCircle, AlertCircle } from "lucide-react";
 import { toast } from "sonner";
 
@@ -24,7 +24,10 @@ import {
 } from "@/components/ui/table";
 import { cn, formatNTD } from "@/lib/utils";
 
-import type { JournalEntry } from "@/lib/domain/journal-entry";
+import {
+  buildLineSumsMap,
+  type JournalEntry,
+} from "@/lib/domain/journal-entry";
 import { useVoucherDemoStore } from "@/lib/dev/use-voucher-demo-store";
 
 interface VoucherBatchPostDialogProps {
@@ -40,16 +43,6 @@ interface PostResult {
   error: string | null;
 }
 
-function summarizeEntry(
-  entry: JournalEntry,
-  allLines: { journal_entry_id: string; debit: number; credit: number }[],
-): { debit: number; credit: number; balanced: boolean } {
-  const ls = allLines.filter((l) => l.journal_entry_id === entry.id);
-  const debit = ls.reduce((s, l) => s + l.debit, 0);
-  const credit = ls.reduce((s, l) => s + l.credit, 0);
-  return { debit, credit, balanced: debit === credit && debit > 0 };
-}
-
 export function VoucherBatchPostDialog({
   entries,
   open,
@@ -61,11 +54,19 @@ export function VoucherBatchPostDialog({
   const [results, setResults] = useState<PostResult[] | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
-  const drafts = entries.filter((e) => e.status === "draft");
-  const summaries = drafts.map((e) => ({
-    entry: e,
-    ...summarizeEntry(e, store.lines),
-  }));
+  const drafts = useMemo(
+    () => entries.filter((e) => e.status === "draft"),
+    [entries],
+  );
+
+  const summaries = useMemo(() => {
+    const sums = buildLineSumsMap(store.lines);
+    return drafts.map((entry) => {
+      const { debit, credit } = sums.get(entry.id) ?? { debit: 0, credit: 0 };
+      return { entry, debit, credit, balanced: debit === credit && debit > 0 };
+    });
+  }, [drafts, store.lines]);
+
   const balancedCount = summaries.filter((s) => s.balanced).length;
 
   const handleSubmit = () => {
@@ -99,7 +100,7 @@ export function VoucherBatchPostDialog({
           <DialogDescription className="text-base">
             {results
               ? "過帳結果如下，請逐筆確認。"
-              : `將為以下 ${drafts.length} 筆草稿賦予傳票編號並進入帳本。過帳後不可直接刪除，當年度未關帳前可 in-place edit（需填修改原因）；跨年度後不可改。`}
+              : `將為以下 ${drafts.length} 筆草稿賦予傳票編號並進入帳本。過帳後不可直接刪除，當年度未關帳前可更新（需填修改原因）；跨年度後不可改。`}
           </DialogDescription>
         </DialogHeader>
 
@@ -135,8 +136,10 @@ export function VoucherBatchPostDialog({
                     <TableCell className="text-base">
                       {s.entry.voucher_type}
                     </TableCell>
-                    <TableCell className="text-base max-w-[280px] truncate">
-                      {s.entry.description ?? "—"}
+                    <TableCell className="text-base max-w-[360px]">
+                      <div className="line-clamp-2">
+                        {s.entry.description ?? "—"}
+                      </div>
                     </TableCell>
                     <TableCell className="text-right font-mono text-base">
                       {formatNTD(s.debit)} / {formatNTD(s.credit)}

--- a/components/voucher-edit-dialog.tsx
+++ b/components/voucher-edit-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
 import { useFieldArray, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -51,6 +51,9 @@ import { cn, formatNTD } from "@/lib/utils";
 
 import { ACCOUNT_LIST } from "@/lib/data/accounts";
 import {
+  ACCOUNT_CODE_REGEX,
+  isLinesBalanced,
+  sumLines,
   VOUCHER_TYPE,
   type JournalEntry,
   type JournalEntryLine,
@@ -66,7 +69,7 @@ interface VoucherEditDialogProps {
 
 const lineFormSchema = z
   .object({
-    account_code: z.string().regex(/^\d{4}$/, "請選擇科目"),
+    account_code: z.string().regex(ACCOUNT_CODE_REGEX, "請選擇科目"),
     debit: z.number().int().nonnegative(),
     credit: z.number().int().nonnegative(),
     description: z.string().optional(),
@@ -90,14 +93,10 @@ function buildEditFormSchema(mode: "draft" | "posted") {
       lines: z.array(lineFormSchema).min(2, "至少 2 行"),
       reason: reasonSchema,
     })
-    .refine(
-      (data) => {
-        const debit = data.lines.reduce((s, l) => s + (l.debit || 0), 0);
-        const credit = data.lines.reduce((s, l) => s + (l.credit || 0), 0);
-        return debit === credit && debit > 0;
-      },
-      { message: "借貸不平衡", path: ["lines"] },
-    );
+    .refine((data) => isLinesBalanced(data.lines), {
+      message: "借貸不平衡",
+      path: ["lines"],
+    });
 }
 
 type EditFormValues = z.infer<ReturnType<typeof buildEditFormSchema>>;
@@ -147,27 +146,12 @@ export function VoucherEditDialog({
   });
 
   const watchedLines = form.watch("lines");
-  const debitTotal = watchedLines.reduce((s, l) => s + (Number(l.debit) || 0), 0);
-  const creditTotal = watchedLines.reduce((s, l) => s + (Number(l.credit) || 0), 0);
+  const numericLines = watchedLines.map((l) => ({
+    debit: Number(l.debit) || 0,
+    credit: Number(l.credit) || 0,
+  }));
+  const { debit: debitTotal, credit: creditTotal } = sumLines(numericLines);
   const isBalanced = debitTotal === creditTotal && debitTotal > 0;
-
-  // Reset only when the dialog opens or switches entries — avoid clobbering in-progress edits when the store updates while open.
-  useEffect(() => {
-    if (!open) return;
-    form.reset({
-      voucher_type: entry.voucher_type,
-      entry_date: entry.entry_date,
-      description: entry.description ?? "",
-      lines: initialLines.map((l) => ({
-        account_code: l.account_code,
-        debit: l.debit,
-        credit: l.credit,
-        description: l.description ?? "",
-      })),
-      reason: "",
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, entry.id]);
 
   const onSubmit = (values: EditFormValues) => {
     const newLines = values.lines.map((l, i) => ({

--- a/components/voucher-edit-dialog.tsx
+++ b/components/voucher-edit-dialog.tsx
@@ -1,0 +1,533 @@
+"use client";
+
+import { useEffect, useMemo } from "react";
+import { useFieldArray, useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { format } from "date-fns";
+import { CalendarIcon, Plus, Trash2, AlertTriangle } from "lucide-react";
+import { toast } from "sonner";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Calendar } from "@/components/ui/calendar";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn, formatNTD } from "@/lib/utils";
+
+import { ACCOUNT_LIST } from "@/lib/data/accounts";
+import {
+  VOUCHER_TYPE,
+  type JournalEntry,
+  type JournalEntryLine,
+} from "@/lib/domain/journal-entry";
+import { useVoucherDemoStore } from "@/lib/dev/use-voucher-demo-store";
+
+interface VoucherEditDialogProps {
+  entry: JournalEntry;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSaved?: () => void;
+}
+
+const lineFormSchema = z
+  .object({
+    account_code: z.string().regex(/^\d{4}$/, "請選擇科目"),
+    debit: z.number().int().nonnegative(),
+    credit: z.number().int().nonnegative(),
+    description: z.string().optional(),
+  })
+  .refine((l) => (l.debit > 0) !== (l.credit > 0), {
+    message: "借方與貸方只能擇一為正",
+    path: ["debit"],
+  });
+
+function buildEditFormSchema(mode: "draft" | "posted") {
+  const reasonSchema =
+    mode === "posted"
+      ? z.string().trim().min(1, "修改原因必填")
+      : z.string().optional();
+
+  return z
+    .object({
+      voucher_type: z.enum(VOUCHER_TYPE),
+      entry_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "日期格式錯誤"),
+      description: z.string().optional(),
+      lines: z.array(lineFormSchema).min(2, "至少 2 行"),
+      reason: reasonSchema,
+    })
+    .refine(
+      (data) => {
+        const debit = data.lines.reduce((s, l) => s + (l.debit || 0), 0);
+        const credit = data.lines.reduce((s, l) => s + (l.credit || 0), 0);
+        return debit === credit && debit > 0;
+      },
+      { message: "借貸不平衡", path: ["lines"] },
+    );
+}
+
+type EditFormValues = z.infer<ReturnType<typeof buildEditFormSchema>>;
+
+const ACCOUNT_OPTIONS = ACCOUNT_LIST.map((s) => {
+  const code = s.split(" ")[0];
+  return { code, label: s };
+});
+
+export function VoucherEditDialog({
+  entry,
+  open,
+  onOpenChange,
+  onSaved,
+}: VoucherEditDialogProps) {
+  const store = useVoucherDemoStore();
+  const mode: "draft" | "posted" = entry.status === "posted" ? "posted" : "draft";
+  const schema = useMemo(() => buildEditFormSchema(mode), [mode]);
+
+  const initialLines: JournalEntryLine[] = useMemo(
+    () =>
+      [...store.lines.filter((l) => l.journal_entry_id === entry.id)].sort(
+        (a, b) => a.line_number - b.line_number,
+      ),
+    [store.lines, entry.id],
+  );
+
+  const form = useForm<EditFormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      voucher_type: entry.voucher_type,
+      entry_date: entry.entry_date,
+      description: entry.description ?? "",
+      lines: initialLines.map((l) => ({
+        account_code: l.account_code,
+        debit: l.debit,
+        credit: l.credit,
+        description: l.description ?? "",
+      })),
+      reason: "",
+    },
+  });
+
+  const { fields, append, remove } = useFieldArray({
+    control: form.control,
+    name: "lines",
+  });
+
+  const watchedLines = form.watch("lines");
+  const debitTotal = watchedLines.reduce((s, l) => s + (Number(l.debit) || 0), 0);
+  const creditTotal = watchedLines.reduce((s, l) => s + (Number(l.credit) || 0), 0);
+  const isBalanced = debitTotal === creditTotal && debitTotal > 0;
+
+  // Reset only when the dialog opens or switches entries — avoid clobbering in-progress edits when the store updates while open.
+  useEffect(() => {
+    if (!open) return;
+    form.reset({
+      voucher_type: entry.voucher_type,
+      entry_date: entry.entry_date,
+      description: entry.description ?? "",
+      lines: initialLines.map((l) => ({
+        account_code: l.account_code,
+        debit: l.debit,
+        credit: l.credit,
+        description: l.description ?? "",
+      })),
+      reason: "",
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, entry.id]);
+
+  const onSubmit = (values: EditFormValues) => {
+    const newLines = values.lines.map((l, i) => ({
+      line_number: i + 1,
+      account_code: l.account_code,
+      debit: l.debit,
+      credit: l.credit,
+      description: l.description ? l.description : null,
+    }));
+
+    if (mode === "draft") {
+      store.saveDraftEntry(
+        entry.id,
+        {
+          voucher_type: values.voucher_type,
+          entry_date: values.entry_date,
+          description: values.description ? values.description : null,
+        },
+        newLines,
+      );
+      toast.success("草稿已儲存");
+    } else {
+      store.editPostedEntry(
+        entry.id,
+        {
+          voucher_type: values.voucher_type,
+          entry_date: values.entry_date,
+          description: values.description ? values.description : null,
+        },
+        newLines,
+        values.reason ?? "",
+        store.userId,
+      );
+      toast.success("已更新並寫入審計軌跡");
+    }
+    onOpenChange(false);
+    onSaved?.();
+  };
+
+  const entryDateAsDate = (() => {
+    const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(form.getValues("entry_date"));
+    if (!m) return undefined;
+    return new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
+  })();
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>
+            {mode === "posted" ? "編輯已過帳傳票" : "編輯草稿"}
+          </DialogTitle>
+          <DialogDescription>
+            {mode === "posted" ? (
+              <span className="text-base">
+                傳票編號 <span className="font-mono font-bold">{entry.voucher_no}</span>
+                ；傳票編號與過帳資訊不可改。
+              </span>
+            ) : (
+              <span className="text-base">草稿可自由編輯，過帳前不會佔用傳票編號。</span>
+            )}
+          </DialogDescription>
+        </DialogHeader>
+
+        {mode === "posted" && (
+          <div className="rounded-md border border-amber-300 bg-amber-50 p-3 text-base text-amber-900 flex gap-2 items-start">
+            <AlertTriangle className="size-5 shrink-0 mt-0.5" />
+            <div>
+              <div className="font-medium">已過帳，編輯將寫入審計軌跡</div>
+              <div className="text-sm mt-1">
+                修改原因將永久記錄，由稽核人員可調閱。
+                若年度已關帳則無法編輯——請建立沖銷分錄並於當年度認列「前期損益調整」。
+              </div>
+            </div>
+          </div>
+        )}
+
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              <FormField
+                control={form.control}
+                name="voucher_type"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>傳票類型</FormLabel>
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="請選擇" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {VOUCHER_TYPE.map((v) => (
+                          <SelectItem key={v} value={v}>
+                            {v}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="entry_date"
+                render={({ field }) => (
+                  <FormItem className="flex flex-col">
+                    <FormLabel>記帳日期</FormLabel>
+                    <Popover>
+                      <PopoverTrigger asChild>
+                        <FormControl>
+                          <Button
+                            type="button"
+                            variant="outline"
+                            className={cn(
+                              "justify-start text-left font-normal",
+                              !field.value && "text-muted-foreground",
+                            )}
+                          >
+                            <CalendarIcon className="mr-2 h-4 w-4" />
+                            {field.value || "請選日期"}
+                          </Button>
+                        </FormControl>
+                      </PopoverTrigger>
+                      <PopoverContent className="w-auto p-0" align="start">
+                        <Calendar
+                          mode="single"
+                          selected={entryDateAsDate}
+                          onSelect={(d) => {
+                            if (!d) return;
+                            field.onChange(format(d, "yyyy-MM-dd"));
+                          }}
+                          autoFocus
+                        />
+                      </PopoverContent>
+                    </Popover>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="description"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>摘要</FormLabel>
+                    <FormControl>
+                      <Input {...field} placeholder="（選填）" />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <div>
+              <div className="flex items-center justify-between mb-2">
+                <div className="text-base font-medium">分錄</div>
+                <div className="flex items-center gap-3">
+                  <span
+                    className={cn(
+                      "text-base",
+                      isBalanced ? "text-emerald-700" : "text-destructive",
+                    )}
+                  >
+                    {isBalanced ? "✓ 借貸平衡" : "✗ 借貸不平衡"}
+                    <span className="ml-2 font-mono">
+                      {formatNTD(debitTotal)} / {formatNTD(creditTotal)}
+                    </span>
+                  </span>
+                </div>
+              </div>
+
+              <div className="rounded-md border">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead className="w-12">#</TableHead>
+                      <TableHead>科目</TableHead>
+                      <TableHead className="w-32 text-right">借方</TableHead>
+                      <TableHead className="w-32 text-right">貸方</TableHead>
+                      <TableHead>備註</TableHead>
+                      <TableHead className="w-12"></TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {fields.map((field, idx) => (
+                      <TableRow key={field.id}>
+                        <TableCell className="text-base text-muted-foreground">
+                          {idx + 1}
+                        </TableCell>
+                        <TableCell>
+                          <FormField
+                            control={form.control}
+                            name={`lines.${idx}.account_code`}
+                            render={({ field: af }) => (
+                              <FormItem>
+                                <Select value={af.value} onValueChange={af.onChange}>
+                                  <FormControl>
+                                    <SelectTrigger>
+                                      <SelectValue placeholder="選擇科目" />
+                                    </SelectTrigger>
+                                  </FormControl>
+                                  <SelectContent className="max-h-72">
+                                    {ACCOUNT_OPTIONS.map((opt) => (
+                                      <SelectItem key={opt.code} value={opt.code}>
+                                        {opt.label}
+                                      </SelectItem>
+                                    ))}
+                                  </SelectContent>
+                                </Select>
+                                <FormMessage />
+                              </FormItem>
+                            )}
+                          />
+                        </TableCell>
+                        <TableCell>
+                          <FormField
+                            control={form.control}
+                            name={`lines.${idx}.debit`}
+                            render={({ field: af }) => (
+                              <FormItem>
+                                <FormControl>
+                                  <Input
+                                    type="number"
+                                    inputMode="numeric"
+                                    className="text-right font-mono"
+                                    value={af.value === 0 ? "" : af.value}
+                                    onChange={(e) =>
+                                      af.onChange(
+                                        e.target.value === "" ? 0 : Number(e.target.value),
+                                      )
+                                    }
+                                  />
+                                </FormControl>
+                                <FormMessage />
+                              </FormItem>
+                            )}
+                          />
+                        </TableCell>
+                        <TableCell>
+                          <FormField
+                            control={form.control}
+                            name={`lines.${idx}.credit`}
+                            render={({ field: af }) => (
+                              <FormItem>
+                                <FormControl>
+                                  <Input
+                                    type="number"
+                                    inputMode="numeric"
+                                    className="text-right font-mono"
+                                    value={af.value === 0 ? "" : af.value}
+                                    onChange={(e) =>
+                                      af.onChange(
+                                        e.target.value === "" ? 0 : Number(e.target.value),
+                                      )
+                                    }
+                                  />
+                                </FormControl>
+                                <FormMessage />
+                              </FormItem>
+                            )}
+                          />
+                        </TableCell>
+                        <TableCell>
+                          <FormField
+                            control={form.control}
+                            name={`lines.${idx}.description`}
+                            render={({ field: af }) => (
+                              <FormItem>
+                                <FormControl>
+                                  <Input {...af} placeholder="（選填）" />
+                                </FormControl>
+                              </FormItem>
+                            )}
+                          />
+                        </TableCell>
+                        <TableCell>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => remove(idx)}
+                            disabled={fields.length <= 2}
+                          >
+                            <Trash2 className="size-4" />
+                          </Button>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="mt-2"
+                onClick={() =>
+                  append({
+                    account_code: "",
+                    debit: 0,
+                    credit: 0,
+                    description: "",
+                  })
+                }
+              >
+                <Plus className="size-4 mr-1" />
+                新增一行
+              </Button>
+
+              {form.formState.errors.lines?.message && (
+                <p className="text-sm text-destructive mt-2">
+                  {form.formState.errors.lines.message}
+                </p>
+              )}
+            </div>
+
+            {mode === "posted" && (
+              <FormField
+                control={form.control}
+                name="reason"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      修改原因 <span className="text-destructive">*</span>
+                    </FormLabel>
+                    <FormControl>
+                      <Input
+                        {...field}
+                        placeholder="例：OCR 將旅費誤判為文具用品費，依實際發票內容修正"
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            )}
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+              >
+                取消
+              </Button>
+              <Button type="submit" disabled={!isBalanced}>
+                {mode === "posted" ? "儲存修改並寫入審計軌跡" : "儲存草稿"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+

--- a/components/voucher-reverse-dialog.tsx
+++ b/components/voucher-reverse-dialog.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { format } from "date-fns";
+import { CalendarIcon, AlertTriangle } from "lucide-react";
+import { useRouter, useParams } from "next/navigation";
+import { toast } from "sonner";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Calendar } from "@/components/ui/calendar";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+import type { JournalEntry } from "@/lib/domain/journal-entry";
+import { useVoucherDemoStore } from "@/lib/dev/use-voucher-demo-store";
+
+interface VoucherReverseDialogProps {
+  entry: JournalEntry;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function VoucherReverseDialog({
+  entry,
+  open,
+  onOpenChange,
+}: VoucherReverseDialogProps) {
+  const store = useVoucherDemoStore();
+  const router = useRouter();
+  const { firmId, clientId } = useParams() as {
+    firmId: string;
+    clientId: string;
+  };
+
+  const [reason, setReason] = useState("");
+  const [entryDate, setEntryDate] = useState(() => format(new Date(), "yyyy-MM-dd"));
+
+  useEffect(() => {
+    if (!open) {
+      setReason("");
+      setEntryDate(format(new Date(), "yyyy-MM-dd"));
+    }
+  }, [open]);
+
+  const dateAsDate = (() => {
+    const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(entryDate);
+    if (!m) return undefined;
+    return new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
+  })();
+
+  const handleSubmit = () => {
+    if (!reason.trim()) {
+      toast.error("沖銷原因必填");
+      return;
+    }
+    const newId = store.reverseEntry(entry.id, reason.trim(), store.userId, entryDate);
+    if (!newId) {
+      toast.error("無法沖銷（可能已被沖銷或不是 posted 狀態）");
+      return;
+    }
+    toast.success("已建立反向分錄");
+    onOpenChange(false);
+    router.push(`/firm/${firmId}/client/${clientId}/voucher/${newId}`);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-xl">
+        <DialogHeader>
+          <DialogTitle>沖銷此傳票</DialogTitle>
+          <DialogDescription className="text-base">
+            原傳票{" "}
+            <span className="font-mono font-bold">{entry.voucher_no}</span>{" "}
+            將標記為已沖銷；同時建立一筆反向分錄（借貸對調）於指定日期認列。
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="rounded-md border border-amber-300 bg-amber-50 p-3 text-base text-amber-900 flex gap-2 items-start">
+          <AlertTriangle className="size-5 shrink-0 mt-0.5" />
+          <div>
+            <div className="font-medium">何時用沖銷而非編輯？</div>
+            <div className="text-sm mt-1">
+              當業務上真的發生退貨 / 取消 / 廠商重開時用沖銷。
+              若只是 OCR 或 key-in 抓錯，請改用「編輯」直接 in-place 修正
+              （當年度未關帳前可用，會留下審計軌跡）。
+            </div>
+          </div>
+        </div>
+
+        <div className="space-y-4">
+          <div>
+            <Label htmlFor="reverse-date" className="text-base">
+              反向分錄記帳日期
+            </Label>
+            <div className="mt-1">
+              <Popover>
+                <PopoverTrigger asChild>
+                  <Button
+                    id="reverse-date"
+                    type="button"
+                    variant="outline"
+                    className={cn(
+                      "w-full justify-start text-left font-normal",
+                      !entryDate && "text-muted-foreground",
+                    )}
+                  >
+                    <CalendarIcon className="mr-2 h-4 w-4" />
+                    {entryDate || "請選日期"}
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className="w-auto p-0" align="start">
+                  <Calendar
+                    mode="single"
+                    selected={dateAsDate}
+                    onSelect={(d) => {
+                      if (d) setEntryDate(format(d, "yyyy-MM-dd"));
+                    }}
+                    autoFocus
+                  />
+                </PopoverContent>
+              </Popover>
+            </div>
+            <p className="text-sm text-muted-foreground mt-1">
+              預設為今天；若要在其他日期認列沖銷可調整。年度已關帳的日期不允許。
+            </p>
+          </div>
+
+          <div>
+            <Label htmlFor="reverse-reason" className="text-base">
+              沖銷原因 <span className="text-destructive">*</span>
+            </Label>
+            <Input
+              id="reverse-reason"
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              placeholder="例：客戶取消訂單，全額退回；或廠商發現開錯，已重開新發票"
+              className="mt-1"
+            />
+            <p className="text-sm text-muted-foreground mt-1">
+              將永久記錄在審計軌跡中。
+            </p>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            維持原狀
+          </Button>
+          <Button onClick={handleSubmit} variant="destructive">
+            確認沖銷
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/docs/VOUCHER_JOURNAL_ENTRY_PHASED_PLAN.md
+++ b/docs/VOUCHER_JOURNAL_ENTRY_PHASED_PLAN.md
@@ -1,0 +1,374 @@
+# 憑證 / 分錄 / 總帳 — 階段式實作計畫
+
+> **狀態追蹤**
+> - ✅ Phase 1 完成（domain types + fake generator + dev store；72/72 測試綠）
+> - ⏳ Phase 2 待啟動（傳票 UI）
+>
+> **配套文件**：[`VOUCHER_JOURNAL_ENTRY_PLAN.md`](./VOUCHER_JOURNAL_ENTRY_PLAN.md) — 已收斂的設計提案（Decisions #1–#12）。本文件中所有 §x.y 章節編號皆指向設計提案。
+
+## Context
+
+`docs/VOUCHER_JOURNAL_ENTRY_PLAN.md` 是已收斂的設計提案（Decisions #1–#12 已敲定）。本計畫把實作切成 **11 個可獨立交付、可獨立驗證的階段**。
+
+**順序原則**（依使用者要求重排）：
+1. **UI 儘早上場、且早期不鎖 schema**：Phase 1–4 完全不碰 DB / 不寫 migration。Domain types（Zod）+ in-memory fake generator 餵養 UI，可以反覆改 schema 形狀而不付遷移成本。
+2. **UI/UX 確定後才實作 API / DB wiring**：RPC、CTI backfill、原子操作這些「已知怎麼做」的部分排在後面。
+3. **In-place edit 早於 reverse**：使用者明確要求。
+4. **Invoice 改動處同步處理 allowance**：Allowance 在 CTI / generation / posted edit 連動 / review dialog 等所有面向都要鏡像 invoice 的改法。
+5. **fiscal_year_closes guard 隨各 RPC 一起加**，最終的「關帳動作 + UI」才是獨立階段。
+
+**關於 /documents 頁面**：v1 不做。`documents` 表在 v1 純為 CTI 父表（後端概念，依 Q13 建議），唯二的 `doc_type` 是 `invoice` / `allowance`，期別頁（`/period/[periodYYYMM]`）已分別呈現。當 v2+ 加入非 VAT 子表（`receipt` / `payroll` / `insurance` / `manual`）時，一個「其他憑證」頁面才會有業務價值；schema 從 day 1 就能容納，無遷移負擔。
+
+**v1 範圍外**：固定資產 / 攤提（§3.7、§3.8）、發票同期作廢 void（§5.6）、補申報、`extracted_data.account` 雙表示法收斂、account_period_balances rollup、/documents 獨立頁面。
+
+---
+
+## ✅ Phase 1 — Domain types + Fake data generator（**無 DB**）
+
+**狀態**：完成（commit 待開）。
+
+**目標**：定義 v1 GL 模組所有資料形狀的 Zod schemas，並寫一個可餵給 UI 的 in-memory fake data generator。**完全不寫 migration**。讓 phase 2/3 的 UI 可以反覆迭代而不付任何 schema 遷移成本。
+
+**已交付**：
+- `lib/domain/document.ts`：Zod `documentSchema` + `DOC_TYPE` / `DOC_STATUS` / `DOC_VAT_TYPE` / `DOC_OCR_STATUS` enums + 對應 TS 類型
+- `lib/domain/journal-entry.ts`：Zod `journalEntrySchema`（含 `posted/reversed 必須有 voucher_no` refine）+ `journalEntryLineSchema`（含借貸 XOR refine）+ composite `journalEntryWithLinesSchema` + `VOUCHER_TYPE` / `ENTRY_STATUS` enums
+- `lib/domain/audit-trail.ts`：Zod `auditTrailSchema` + `AUDIT_ACTION` / `AUDIT_ENTITY_TABLE` enums
+- `tests/fixtures/voucher-demo-generator.ts`：`generateVoucherDemoData()` 用 counter-based 確定性 UUID，產出 9 筆 entries（3 drafts、5 posted、1 reversed；含 1 筆 posted-edited、1 筆系統分錄、1 筆缺科目 draft）+ 6 documents + 2 audit_trails
+- `lib/dev/use-voucher-demo-store.ts`：`useSyncExternalStore`-backed 模組級 singleton（沿用 `hooks/use-infinite-query.ts` pattern）；mutations 包含 `saveDraftEntry` / `deleteDraftEntry` / `postEntries`（模擬 voucher_no seq）/ `editPostedEntry`（寫 audit row）/ `reverseEntry`（借貸對調 + 寫 audit row）/ `reset`
+- `tests/fixtures/voucher-demo-generator.test.ts`：9 個測試（schema parsing、確定性、狀態覆蓋、借貸平衡 invariant、voucher_no 格式、line→entry FK 完整性）
+
+**驗證紀錄**：`npm run lint` 無新錯誤；`npm run test:run` 72/72 全綠（含新增 9）。
+
+---
+
+## Phase 2 — 傳票 UI 全套（讀 fake generator、互動更新 in-memory store）
+
+**目標**：把使用者可看到 / 互動的所有傳票 UI 一次畫完，與使用者敲定 UX。**所有讀寫都走 phase 1 的 in-memory store**。
+
+**改動**：
+- `app/firm/[firmId]/client/[clientId]/voucher/page.tsx`：傳票列表
+  - 篩選：status（draft / posted / posted-edited / reversed）、日期範圍、客戶／文件類型
+  - 勾選欄 + 批次 post 按鈕（§5.8 friction：confirmation dialog、必勾「我已逐筆檢查」）
+  - 視覺區隔：draft 虛線淡灰、posted 實線白底 + voucher_no 粗體、reversed 灰底刪除線、posted-edited 加「✎ N 次」
+  - 分頁（沿用 `usePaginatedPeriodInvoices` 的 SWR 模式形狀，但內部讀 store）
+- `app/firm/[firmId]/client/[clientId]/voucher/[entryId]/page.tsx`：傳票詳情
+  - Header（voucher_no、日期、status、posted by/at）
+  - Lines 表（line_number / account / debit / credit / description）
+  - 行動按鈕依 status：draft → 編輯／刪除／過帳；posted → 編輯（in-place edit）／沖銷；reversed → 連結反向分錄
+  - 反向 / 被反向：雙向連結
+  - 連結回對應 document（若有；NULL 則顯示「（無原始憑證）」處理系統分錄）
+- `components/voucher-edit-dialog.tsx`：傳票編輯 dialog
+  - Draft 模式：直接編輯 lines、無 reason 欄位
+  - Posted 模式：reason 必填欄位（紅字提示「修改原因將永久記錄在審計軌跡中」）、`voucher_no` readonly、`posted_at` / `posted_by` readonly
+  - shadcn Form + react-hook-form + Zod，沿用 `invoice-review-dialog.tsx` pattern
+- `components/voucher-audit-history.tsx`：審計歷史 viewer（從 store 讀 audit_trails；diff 視覺化）
+- `components/voucher-batch-post-dialog.tsx`：批次過帳 confirmation dialog（列出選取 entries、預期 voucher_no 範圍、checkbox「我已逐筆檢查」、submit 後 store 賦予假連續 voucher_no 並翻 status）
+- `components/voucher-reverse-dialog.tsx`：沖銷 dialog（reason 必填、新分錄 entry_date 預設今天可改）
+- `components/firm-sidebar.tsx`：加「傳票」入口
+- `app/firm/[firmId]/client/[clientId]/period/[periodYYYMM]/page.tsx`：confirmed invoice / **allowance 兩處**都加「已產生 draft 傳票」連結（連到 voucher 詳情；id 由 store mock 對應）
+
+**驗證**：
+- `npm run dev` → 走完所有 UI flow（filter 切換、勾選、批次 post 對話框、編輯 draft、編輯 posted、沖銷、看審計歷史、in-memory mutations 即時反映）
+- 與使用者多輪 review；**這個階段預期會反覆迭代**，因為沒有 DB lock-in，改動成本接近零
+- text-base / text-sm 規則遵守
+- 不影響任何既有功能（沒改任何 service action）
+
+**退出條件**：使用者點頭，所有互動 mockup 過審；型別 / 欄位 / 互動已穩定到可以鎖 schema。
+
+---
+
+## Phase 3 — 損益表 / 資產負債表 UI（讀 fake generator 即時 SUM）
+
+**目標**：把財報頁面畫完。即時 SUM 邏輯本身簡單；本階段 UI + 計算邏輯一起出，仍走 phase 1 的 store。
+
+**改動**：
+- `lib/services/financial-statements.ts`：`getIncomeStatement(clientId, fromDate, toDate)`、`getBalanceSheet(clientId, asOfDate)`，§6.1 即時 SUM、§6.2 科目首碼分類。**phase 3 內讀 store**；phase 5 切到 DB 時實作不變、只改資料來源
+- `app/firm/[firmId]/client/[clientId]/reports/income-statement/page.tsx`：
+  - 期間選擇器（任意 Gregorian 月份 + ROC 申報期快捷，沿用 `RocPeriod`）
+  - 收入 / 成本 / 費用 / 業外 / 所得稅 折疊區塊
+  - 淨利大字
+- `app/firm/[firmId]/client/[clientId]/reports/balance-sheet/page.tsx`：
+  - 截止日選擇器
+  - 資產 / 負債 / 權益 三欄
+  - 借貸總計（強制相等斷言；不等則紅字警示）
+- `components/firm-sidebar.tsx`：加「損益表」、「資產負債表」入口
+- 沿用 `lib/utils.ts`；如有需要可加 `formatNTD` helper
+
+**驗證**：
+- 用 phase 1 fake data 手算 IS / BS 對得上頁面
+- 與使用者 review 版面、欄位、捲動行為
+
+**退出條件**：使用者點頭；報表計算邏輯（首碼分類、IS/BS 公式）在 fake data 上驗證正確。
+
+---
+
+## Phase 4 — 純函式：分錄推導 + 帳號代碼解析
+
+**目標**：把「從 invoice / allowance 推導出分錄」的純邏輯寫滿並用單元測試覆蓋。**仍不碰 DB**。為 phase 7 預備可信賴的計算核心。
+
+**改動**：
+- `lib/services/journal-entry-generation.ts`：
+  - `computeEntryFromInvoice(invoice)` → `{ voucher_type, entry_date, description, lines[] }`
+  - `computeEntryFromAllowance(allowance)` → 同上
+  - 涵蓋 §5.2 全部樣板：進項可扣抵 / 不可扣抵、銷項、進項折讓、銷項折讓
+  - §5.1 結算科目門檻：≤ 10,000 → `1111`，> 10,000 → `1112`
+- `lib/services/journal-entry-generation.test.ts`：完整單元測試，cases 涵蓋 §5.3 範例 A、B、五種樣板、缺 `extracted_data.account` placeholder
+- `lib/data/accounts.ts`：加 `extractAccountCode(fullString)`（`"5102 旅費"` → `"5102"`）+ runtime check：所有 `ACCOUNT_LIST` 字串符合 `/^\d{4} \S/`
+- `lib/data/accounts.test.ts`：覆蓋 extractAccountCode（單寬空白、多空白、無空白應 throw）
+
+**驗證**：
+- `npm test` 全綠
+- 沒碰 DB、沒改 UI
+
+**退出條件**：所有樣板的 debit / credit 與 account_code 都通過單元測試。
+
+---
+
+## Phase 5 — Schema 落地 + 切換 UI 至真實 DB
+
+**目標**：UI / 計算邏輯都已在 fake data 上驗過；現在把 schema 落到 DB 並把 UI 從 store 切到真實 service。**Journal entries / lines / documents 此刻仍為空表**（CTI backfill 在 phase 6、`confirm_invoice` 真實寫入在 phase 7），所以 voucher 列表會顯示「尚無資料」，這是預期行為。
+
+**改動**：
+- Migrations（單一 commit）：
+  - `<ts>_create_documents.sql`(§3.1 + RLS + indices)
+  - `<ts>_create_journal_entries.sql`(§3.3 + §3.4 + RLS + indices + CHECK)
+  - `<ts>_create_voucher_sequences.sql`(§3.5 + RLS)
+  - `<ts>_create_fiscal_year_closes.sql`(§3.6 + RLS)
+  - `<ts>_create_audit_trails.sql`(§3.9 + indices + RLS)
+  - 所有 RLS 鏡像 `invoices` 政策（`firm_id = public.get_auth_user_firm_id()` + super_admin 旁路）
+- `lib/services/journal-entry.ts`、`document.ts`、`audit-trail.ts`：read helpers（`getEntry` / `listEntriesByClient` / `getEntryWithLines` / `listAuditTrailsForEntity`）—— 與 phase 1 store API 同形狀，UI 不改
+- 切換點：phase 1 的 `useVoucherDemoStore` 替換為 `useVoucherStore`（內部用 SWR + Supabase）；hook 簽章不變、UI 完全不動
+- `lib/services/financial-statements.ts`：phase 3 內部從 store 改為 SQL（§6.1 即時 SUM）
+- `tests/utils/supabase.ts`：cleanup 加新表 cascade
+- 重新產生 `supabase/database.types.ts`
+- **保留 fake generator** 在 dev 模式下可選（`?demo=1` query param 切換），方便日後還想用 fake data 驗 UI 的場景
+
+**驗證**：
+- Migrations 套用乾淨；type-check 通過
+- Integration test：CHECK 真擋住違規 row（debit/credit 同正、status 非法值、voucher_no posted 時不可 NULL）
+- Integration test：RLS 真隔離（service-role 看得到、一般使用者只看得到自家 firm）
+- 手動：傳票 / IS / BS 三頁切到真 DB 後，列表顯示「尚無資料」（預期）；既有期別頁、TET_U 匯出完全不退步
+- 既有 invoice / allowance 整合測試全綠
+
+**退出條件**：UI 從 store 切到 service，所有頁面渲染正常（即使內容為空）。
+
+---
+
+## Phase 6 — `documents` CTI backfill（invoices + **allowances 同步**）
+
+**目標**：把既有 invoices 與 allowances 收斂到 documents 之下。Phase 5 已建空表；本階段做 backfill + 加 `NOT NULL UNIQUE`。
+
+**改動**：
+- Migration `<ts>_backfill_documents_from_invoices_allowances.sql`：
+  - 為每張既有 `invoice` INSERT 對應 documents row（`doc_type='invoice'`、`type='VAT'`、`doc_date = extracted_data.date` 缺漏退回 `created_at::date`、`amount = extracted_data.totalAmount`、`file_url = storage_path`、`status='active'`、firm_id / client_id 從 invoice 帶）
+  - **同次 backfill 處理 allowances**（`doc_type='allowance'`、`type='VAT'`、`amount = extracted_data.amount + taxAmount`、其他欄位 mapping 同上）
+  - `invoices` 加 `document_id UUID`（先 nullable）→ 回填 → `RAISE EXCEPTION` 若仍 NULL（fail loud）→ 加 `NOT NULL UNIQUE`
+  - **同次 migration 對 `allowances` 做完全相同的處理**：加欄位 → 回填 → fail loud → NOT NULL UNIQUE
+- `lib/services/document.ts`：補 `createDocument` / `updateDocument` helpers（純表操作）
+- 重新產生 `supabase/database.types.ts`
+
+**參考**：`supabase/migrations/20260126000001_backfill_periods.sql` 為相同 pattern。
+
+**驗證**：
+- Integration test：
+  - `SELECT count(*) FROM invoices WHERE document_id IS NULL` = 0
+  - `SELECT count(*) FROM allowances WHERE document_id IS NULL` = 0
+  - `SELECT count(*) FROM documents d JOIN invoices i ON i.document_id = d.id WHERE d.firm_id != i.firm_id` = 0
+  - 同上 for allowances
+- 既有 invoice / allowance 整合測試全綠
+- 手動：既有期別頁、TET_U 報表匯出完全正常
+
+**退出條件**：CTI 完成（雙子表）；既有功能不退步。
+
+---
+
+## Phase 7 — `confirm_invoice` + `confirm_allowance` + `regenerate_draft_entry` RPCs
+
+**目標**：把 phase 4 的純邏輯接上 DB，原子地產生 draft entries。Phase 2 的傳票 UI 此刻開始顯示真實 draft entries。**Invoice 與 allowance 兩條 confirm 路徑都要處理**。
+
+**改動**：
+- Migration `<ts>_create_confirm_invoice_rpc.sql`：PL/pgSQL — 取 invoice → upsert documents → upsert journal_entry（status=draft、voucher_no=NULL、document_id 指對應 documents）→ replace lines。Idempotent。
+- Migration `<ts>_create_confirm_allowance_rpc.sql`：**同樣邏輯處理 allowance**（樣板不同：進項折讓 / 銷項折讓兩種）
+- Migration `<ts>_create_regenerate_draft_entry_rpc.sql`：吃 `entity_type` + `entity_id`（invoice 或 allowance），要求對應 entry.status='draft' 否則 RAISE EXCEPTION。Lines wholesale DELETE + INSERT，header in-place UPDATE 保 entry.id（§5 重生策略）
+- `lib/services/invoice.ts::updateInvoice`：status 翻到 confirmed → `supabase.rpc('confirm_invoice')`；編輯 confirmed invoice 且 entry='draft' → `regenerate_draft_entry`
+- `lib/services/allowance.ts`：**鏡像 invoice 的所有改動** — `updateAllowance` 同樣派發到 `confirm_allowance` / `regenerate_draft_entry`
+
+**驗證**：
+- Integration tests `tests/integration/services/journal-entry-generation.test.ts`：
+  - 確認新 invoice → draft entry + lines 正確（4 種樣板：進項可扣抵 / 不可扣抵 / 銷項 / 缺 account）
+  - **確認新 allowance → draft entry + lines 正確（2 種樣板：進項折讓 / 銷項折讓）**
+  - 編輯已 confirmed invoice（draft 已存在）→ entry.id 保留、lines 整批替換
+  - 編輯已 confirmed allowance（draft 已存在）→ 同上
+  - 編輯已 confirmed invoice / allowance 但 entry 已 posted → regenerate 拒絕
+- 手動：confirm 一張 invoice + 一張 allowance → 進傳票列表 → 兩筆 draft 正確顯示
+
+**退出條件**：所有 confirmed invoice / allowance 都自動產生對應 draft entry。
+
+---
+
+## Phase 8 — `post_journal_entries` RPC（接 phase 2 的批次過帳）
+
+**目標**：phase 2 已建好的「批次過帳」按鈕從 in-memory mutation 切到真實 RPC。
+
+**改動**：
+- Migration `<ts>_create_post_journal_entries_rpc.sql`：完整實作 §5.4
+  - FOR UPDATE 排序、status check、balance check、**fiscal_year_closes guard**、atomic seq UPSERT（`voucher_sequences`）、status flip
+  - **no-gap 紀律 4 條全部遵守**（table-based seq、所有 fail check 在 seq 消耗之前、不用 SAVEPOINT、UPDATE 不可能失敗）
+- `lib/services/journal-entry.ts`：加 `postJournalEntries(entryIds, userId)` → `supabase.rpc(...)`
+- 把 phase 2 的批次過帳 dialog 從 store mutation 切到真 RPC；過帳完成後 inline 顯示逐筆結果（成功 ✓ + voucher_no、失敗紅字 + error）
+
+**驗證**：
+- Integration test `tests/integration/services/post-journal-entries.test.ts`：
+  - happy（單筆 + 批次）、idempotent、unbalanced 拒絕
+  - 部分成功 → 成功者的 voucher_no 連續無 gap（**核心 invariant**）
+  - 不同 client 並發互不阻塞
+  - 已關帳年度的 entry_date 拒絕（guard 內建，phase 11 close action 會驗）
+- 手動：confirm 5 張 invoice / allowance 混合 → 批次選取 → post → 5 個連號 voucher_no
+
+**退出條件**：no-gap test 通過；UI 過帳流程順手。
+
+---
+
+## Phase 9 — `edit_posted_entry` RPC + audit_trails 必填寫入路徑（in-place edit）
+
+**目標**：phase 2 已建好的「編輯 posted」dialog 從 store mutation 切到真 RPC。**早於 reverse**（依使用者要求）：in-place edit 處理高頻 OCR / key-in 錯。**Invoice 與 allowance 兩條編輯連動路徑都要處理**。
+
+**改動**：
+- Migration `<ts>_create_edit_posted_entry_rpc.sql`：取舊 row + lines snapshot → UPDATE entry header（`voucher_no` / `posted_at` / `posted_by` / `created_*` 不可改）→ DELETE + INSERT lines → INSERT audit_trails row（`action='updated'`、before 必填、reason 必填、actor_id = userId）。**fiscal_year_closes guard**。
+- `lib/services/journal-entry.ts`：加 `editPostedEntry(id, patch, reason, userId)`
+- `lib/services/audit-trail.ts`：補 `getStateAfter(auditRow)` helper（§3.9）
+- `lib/services/invoice.ts::updateInvoice`：當員工編輯一張 confirmed invoice 對應的 entry 已 posted（§5.6.1 路徑 B1b）→ dispatch 至 `editPostedEntry`，連動 in-place update entry
+- `lib/services/allowance.ts::updateAllowance`：**鏡像 invoice 的派發邏輯** — confirmed allowance 對應 entry 已 posted 時，連動 editPostedEntry
+- `components/invoice-review-dialog.tsx`：當對應 entry='posted' 時加 reason 欄位 + 警示條：「⚠️ 此發票已過帳為傳票 X，修改將連動更新該傳票並留下審計記錄」
+- `components/allowance-review-dialog.tsx`：**同樣加 reason 欄位 + 警示條**（鏡像 invoice review dialog）
+- 把 phase 2 的 voucher edit dialog（posted 模式）+ audit history viewer 從 store 切到真 service
+
+**驗證**：
+- Integration test：
+  - editPostedEntry → audit_trails before snapshot 等於改前 row state
+  - 連續多次 edit → 每筆 audit before = 前一筆 audit 的「after」（透過 getStateAfter 推導）—— **chain 完整性**
+  - 已關帳年度拒絕（guard）
+  - 透過 invoice 編輯路徑連動觸發 editPostedEntry → audit_trails 正確
+  - **同上 for allowance 編輯路徑**
+- 手動：編輯 posted entry → reason 必填 → 提交後 voucher_no 不變、變更歷史可展開
+
+**退出條件**：路徑 1（直接改帳本）+ 路徑 2 連動（改 invoice / 改 allowance 連動 entry）皆通過 §5.6.1 決策表 B1b。
+
+---
+
+## Phase 10 — `reverse_entry` RPC（沖銷）
+
+**目標**：phase 2 已建好的「沖銷」按鈕從 store mutation 切到真 RPC。
+
+**改動**：
+- Migration `<ts>_create_reverse_entry_rpc.sql`：原子地 (1) INSERT 新 journal_entry（lines 借貸對調、`reverses_entry_id` 指原 entry、entry_date 由呼叫者帶入、預設今天、新 entry 自帶 voucher_no via seq）(2) 原 entry status → `reversed`，同時 INSERT audit_trails row（entity=原 entry、action='reversed'、reason 必填）。**fiscal_year_closes guard 對新 entry 的 entry_date 套用**（原 entry 的 entry_date 可能在已關帳年度，這是允許的）
+- `lib/services/journal-entry.ts`：加 `reverseEntry(entryId, reason, userId, entryDate?)`
+- 把 phase 2 的沖銷 dialog 從 store mutation 切到真 RPC
+
+**驗證**：
+- Integration test：沖銷 happy（新 entry 借貸對調、reverses_entry_id 正確、原 entry status='reversed'）/ 已 reversed 不能再沖 / reason 必填 / 新 entry entry_date 落在已關帳年度 → guard 拒絕 / IS-BS 加總（反向分錄抵消原分錄）
+- 手動：post 一張錯的 → 點沖銷 → 看到原 entry 變灰 + 新反向分錄連回
+
+**退出條件**：員工有沖銷逃生口；UI 從 store 完全接通。
+
+---
+
+## Phase 11 — 年度關帳
+
+**目標**：上線「鎖定該年度帳本」的管理動作。`fiscal_year_closes` 表自 phase 5 起即存在；每個會碰 entry_date 的 RPC（phase 8 / 9 / 10）都已內建 guard。
+
+**改動**：
+- `lib/services/fiscal-year-close.ts`：`closeFiscalYear(clientId, year, userId, notes?)`（要求該年度無 draft entries）、`reopenFiscalYear(closeId)`
+- `app/firm/[firmId]/client/[clientId]/fiscal-year-close/page.tsx`：admin 觸發頁面（角色為 admin / super_admin 才顯示）
+- `components/firm-sidebar.tsx`：加「年度關帳」入口（依角色顯示）
+
+**驗證**：
+- Integration test：關帳後 post / reverse / editPostedEntry 對該年度 entry_date 全部拒絕；reopen 後恢復；該年度 IS/BS 數字凍結
+- 手動：實機跑一次關帳 → 嘗試編輯 → 預期看到拒絕訊息
+
+**退出條件**：v1 GL 模組功能閉環。
+
+---
+
+## v1 範圍外（後續另開計畫）
+
+- 固定資產（§3.7）+ 攤提（§3.8）+ amortization-worker（pgmq + pg_cron）
+- 發票同期作廢 void（§5.6 上半）+ 跨期折讓自動產生（§5.6 下半）
+- VAT 補申報流程
+- `account_period_balances` 月度 rollup（觸發條件見 §6.3）
+- `extracted_data.account` 雙表示法收斂（目前 invoice 端存 `"5102 旅費"`、entry line 端存 `"5102"`）
+- audit_trails 全面寫入（v1 僅 posted entry edit / reverse 必填）
+- **/documents 獨立頁面**（v2+ 加入非 VAT `doc_type` 後才有業務意義）
+
+---
+
+## 關鍵檔案 / 函式 reference
+
+**新增 — Phase 1（無 migration，已完成）**：
+- `lib/domain/document.ts`、`journal-entry.ts`、`audit-trail.ts`
+- `tests/fixtures/voucher-demo-generator.ts` + `.test.ts`
+- `lib/dev/use-voucher-demo-store.ts`
+
+**新增 — Phase 2/3（UI）**：
+- `app/firm/[firmId]/client/[clientId]/voucher/page.tsx`、`voucher/[entryId]/page.tsx`
+- `app/firm/[firmId]/client/[clientId]/reports/income-statement/page.tsx`、`reports/balance-sheet/page.tsx`
+- `components/voucher-edit-dialog.tsx`、`voucher-audit-history.tsx`、`voucher-batch-post-dialog.tsx`、`voucher-reverse-dialog.tsx`
+- `lib/services/financial-statements.ts`（phase 3 讀 store → phase 5 改讀 SQL）
+
+**新增 — Phase 4（純函式）**：
+- `lib/services/journal-entry-generation.ts` + `.test.ts`
+
+**新增 — Phase 5（schema + 切換 UI）**：
+- `supabase/migrations/<ts>_create_documents.sql`
+- `supabase/migrations/<ts>_create_journal_entries.sql`
+- `supabase/migrations/<ts>_create_voucher_sequences.sql`
+- `supabase/migrations/<ts>_create_fiscal_year_closes.sql`
+- `supabase/migrations/<ts>_create_audit_trails.sql`
+- `lib/services/journal-entry.ts`、`document.ts`、`audit-trail.ts`（read helpers）
+
+**新增 — Phase 6 起**：
+- `supabase/migrations/<ts>_backfill_documents_from_invoices_allowances.sql`（phase 6，**雙子表同步**）
+- `supabase/migrations/<ts>_create_confirm_invoice_rpc.sql`（phase 7）
+- `supabase/migrations/<ts>_create_confirm_allowance_rpc.sql`（phase 7，**鏡像 invoice 版**）
+- `supabase/migrations/<ts>_create_regenerate_draft_entry_rpc.sql`（phase 7，吃 entity_type + entity_id）
+- `supabase/migrations/<ts>_create_post_journal_entries_rpc.sql`（phase 8）
+- `supabase/migrations/<ts>_create_edit_posted_entry_rpc.sql`（phase 9）
+- `supabase/migrations/<ts>_create_reverse_entry_rpc.sql`（phase 10）
+- `lib/services/fiscal-year-close.ts` + `fiscal-year-close/page.tsx`（phase 11）
+
+**修改**：
+- `lib/services/invoice.ts`（phase 7 接 confirm/regenerate RPC、phase 9 派發至 editPostedEntry）
+- `lib/services/allowance.ts`（**phase 7、phase 9 鏡像 invoice 的所有改動**）
+- `lib/data/accounts.ts`（phase 4 加 extractAccountCode + 格式 lint）
+- `lib/domain/models.ts`（每階段相應 schema）
+- `components/invoice-review-dialog.tsx`（phase 2 加 reason 欄位 + 警示條外觀；phase 9 真接 editPostedEntry）
+- `components/allowance-review-dialog.tsx`（**phase 2 / phase 9 鏡像 invoice review dialog**）
+- `components/firm-sidebar.tsx`（phase 2 / 3 / 11 入口）
+- `app/firm/[firmId]/client/[clientId]/period/[periodYYYMM]/page.tsx`（phase 2 在 invoice + allowance 兩處都加「已產生 draft 傳票」連結）
+- `tests/utils/supabase.ts`（phase 5 cleanup 加新表；phase 6 加 documents）
+- `supabase/database.types.ts`（每次 migration 後 regenerate）
+
+**Reuse 既有**：
+- RLS 函式 `public.get_auth_user_firm_id()`（`supabase/migrations/20251230032712_init.sql:41`）
+- `createTestFixture` / `cleanupTestFixture`（`tests/utils/supabase.ts:104`）
+- `RocPeriod`（`lib/domain/roc-period.ts`）
+- `toRocYearMonth` / `toGregorianDate`（`lib/utils.ts:57`）
+- `ACCOUNT_LIST` / `ACCOUNTS`（`lib/data/accounts.ts`）
+- shadcn Dialog + Form pattern（`components/invoice-review-dialog.tsx`）
+- `usePaginatedPeriodInvoices` SWR pattern（`hooks/use-paginated-period-invoices.ts`）
+
+---
+
+## 端到端驗證腳本（每階段交付前最後一道防線）
+
+每個 phase 都跑：
+1. `npm run supabase:start`（phase 5 起需要）
+2. `npx supabase migration up`（phase 5 起需要）
+3. `npx supabase gen types typescript --local --schema public --schema pgmq_public > supabase/database.types.ts`（phase 5 起每次 migration 後）
+4. `npm run lint`
+5. `npm run test:run`
+6. `npm run dev` → 走完該階段「手動驗證」清單（happy + edge cases）
+7. （phase 6 起）走「既有發票流程不退步」smoke：上傳 invoice → AI extract → review → confirm → 期別頁渲染、TET_U 匯出生成
+8. （phase 7 起）**同上 smoke 對 allowance 跑一次**
+
+每階段完成後 commit + 開 PR，**不**等所有階段一起合併。

--- a/lib/data/accounts.ts
+++ b/lib/data/accounts.ts
@@ -542,3 +542,8 @@ export const ACCOUNT_LIST = [
 
 export type AccountCode = keyof typeof ACCOUNTS;
 export type Account = typeof ACCOUNT_LIST[number];
+
+export function accountLabel(code: string): string {
+  const acc = ACCOUNTS[code as AccountCode];
+  return acc ? `${code} ${acc.name}` : code;
+}

--- a/lib/dev/use-voucher-demo-store.ts
+++ b/lib/dev/use-voucher-demo-store.ts
@@ -5,9 +5,10 @@ import {
   generateVoucherDemoData,
   type VoucherDemoData,
 } from "@/tests/fixtures/voucher-demo-generator";
-import type {
-  JournalEntry,
-  JournalEntryLine,
+import {
+  isLinesBalanced,
+  type JournalEntry,
+  type JournalEntryLine,
 } from "@/lib/domain/journal-entry";
 import type { AuditTrail } from "@/lib/domain/audit-trail";
 import { formatDateToISO } from "@/lib/utils";
@@ -23,6 +24,7 @@ function notify(): void {
 }
 
 function setState(next: VoucherDemoData): void {
+  if (next === _state) return;
   _state = next;
   notify();
 }
@@ -40,6 +42,13 @@ function getSnapshot(): VoucherDemoData {
 
 export function resetVoucherDemoStore(): void {
   setState(generateVoucherDemoData());
+}
+
+// Re-seed the demo so its firmId/clientId match the route the user is viewing.
+// Without this the page filter `e.client_id === clientId` excludes every entry.
+export function seedVoucherDemoFor(firmId: string, clientId: string): void {
+  if (_state.firmId === firmId && _state.clientId === clientId) return;
+  setState(generateVoucherDemoData({ firmId, clientId }));
 }
 
 function genId(): string {
@@ -85,9 +94,7 @@ function postEntries(entryIds: string[], userId: string): PostResult[] {
       continue;
     }
     const entryLines = working.lines.filter((l) => l.journal_entry_id === e.id);
-    const debit = entryLines.reduce((s, l) => s + l.debit, 0);
-    const credit = entryLines.reduce((s, l) => s + l.credit, 0);
-    if (debit !== credit || debit === 0) {
+    if (!isLinesBalanced(entryLines)) {
       results.push({ entry_id: e.id, voucher_no: null, error: "unbalanced" });
       continue;
     }

--- a/lib/dev/use-voucher-demo-store.ts
+++ b/lib/dev/use-voucher-demo-store.ts
@@ -1,0 +1,302 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import {
+  generateVoucherDemoData,
+  type VoucherDemoData,
+} from "@/tests/fixtures/voucher-demo-generator";
+import type {
+  JournalEntry,
+  JournalEntryLine,
+} from "@/lib/domain/journal-entry";
+import type { AuditTrail } from "@/lib/domain/audit-trail";
+import { formatDateToISO } from "@/lib/utils";
+
+// Singleton in-memory store mirroring the shape of phase 5+ DB-backed services,
+// so UI written against this hook keeps working when the impl swaps to Supabase.
+
+let _state: VoucherDemoData = generateVoucherDemoData();
+const _listeners = new Set<() => void>();
+
+function notify(): void {
+  for (const l of _listeners) l();
+}
+
+function setState(next: VoucherDemoData): void {
+  _state = next;
+  notify();
+}
+
+function subscribe(listener: () => void): () => void {
+  _listeners.add(listener);
+  return () => {
+    _listeners.delete(listener);
+  };
+}
+
+function getSnapshot(): VoucherDemoData {
+  return _state;
+}
+
+export function resetVoucherDemoStore(): void {
+  setState(generateVoucherDemoData());
+}
+
+function genId(): string {
+  return globalThis.crypto.randomUUID();
+}
+
+function nextVoucherSeq(
+  state: VoucherDemoData,
+  clientId: string,
+  yyyymmdd: string,
+): number {
+  let max = 0;
+  for (const e of state.entries) {
+    if (e.client_id !== clientId || !e.voucher_no) continue;
+    if (!e.voucher_no.startsWith(`${yyyymmdd}-`)) continue;
+    const seq = Number(e.voucher_no.slice(9));
+    if (seq > max) max = seq;
+  }
+  return max + 1;
+}
+
+interface PostResult {
+  entry_id: string;
+  voucher_no: string | null;
+  error: string | null;
+}
+
+// Mirrors §5.4 partial-success semantics: unbalanced entries fail independently and don't consume a seq, so successful voucher_no remain gap-free.
+function postEntries(entryIds: string[], userId: string): PostResult[] {
+  const results: PostResult[] = [];
+  // Sort by (entry_date, created_at) to mirror RPC's stable ordering
+  const targets = _state.entries
+    .filter((e) => entryIds.includes(e.id))
+    .sort((a, b) => {
+      if (a.entry_date !== b.entry_date) return a.entry_date.localeCompare(b.entry_date);
+      return a.created_at.getTime() - b.created_at.getTime();
+    });
+
+  let working = _state;
+  for (const e of targets) {
+    if (e.status !== "draft") {
+      results.push({ entry_id: e.id, voucher_no: e.voucher_no ?? null, error: null });
+      continue;
+    }
+    const entryLines = working.lines.filter((l) => l.journal_entry_id === e.id);
+    const debit = entryLines.reduce((s, l) => s + l.debit, 0);
+    const credit = entryLines.reduce((s, l) => s + l.credit, 0);
+    if (debit !== credit || debit === 0) {
+      results.push({ entry_id: e.id, voucher_no: null, error: "unbalanced" });
+      continue;
+    }
+    const yyyymmdd = e.entry_date.replaceAll("-", "");
+    const seq = nextVoucherSeq(working, e.client_id, yyyymmdd);
+    const voucher_no = `${yyyymmdd}-${String(seq).padStart(5, "0")}`;
+    working = {
+      ...working,
+      entries: working.entries.map((x) =>
+        x.id === e.id
+          ? {
+              ...x,
+              status: "posted" as const,
+              voucher_no,
+              posted_at: new Date(),
+              posted_by: userId,
+              updated_at: new Date(),
+            }
+          : x,
+      ),
+    };
+    results.push({ entry_id: e.id, voucher_no, error: null });
+  }
+  setState(working);
+  return results;
+}
+
+function saveDraftEntry(
+  entryId: string,
+  patch: Partial<Pick<JournalEntry, "voucher_type" | "entry_date" | "description">>,
+  newLines?: Omit<JournalEntryLine, "id" | "journal_entry_id">[],
+): void {
+  const target = _state.entries.find((e) => e.id === entryId);
+  if (!target || target.status !== "draft") return;
+  if (Object.keys(patch).length === 0 && !newLines) return;
+
+  const nextEntries = _state.entries.map((e) =>
+    e.id === entryId ? { ...e, ...patch, updated_at: new Date() } : e,
+  );
+
+  let nextLines = _state.lines;
+  if (newLines) {
+    const hydrated: JournalEntryLine[] = newLines.map((l) => ({
+      ...l,
+      id: genId(),
+      journal_entry_id: entryId,
+    }));
+    nextLines = [..._state.lines.filter((l) => l.journal_entry_id !== entryId), ...hydrated];
+  }
+  setState({ ..._state, entries: nextEntries, lines: nextLines });
+}
+
+function deleteDraftEntry(entryId: string): void {
+  const target = _state.entries.find((e) => e.id === entryId);
+  if (!target || target.status !== "draft") return;
+  setState({
+    ..._state,
+    entries: _state.entries.filter((e) => e.id !== entryId),
+    lines: _state.lines.filter((l) => l.journal_entry_id !== entryId),
+  });
+}
+
+function editPostedEntry(
+  entryId: string,
+  patch: Partial<Pick<JournalEntry, "voucher_type" | "entry_date" | "description">>,
+  newLines: Omit<JournalEntryLine, "id" | "journal_entry_id">[],
+  reason: string,
+  userId: string,
+): void {
+  const target = _state.entries.find((e) => e.id === entryId);
+  if (!target || target.status !== "posted") return;
+  const oldLines = _state.lines.filter((l) => l.journal_entry_id === entryId);
+
+  const audit: AuditTrail = {
+    id: genId(),
+    firm_id: target.firm_id,
+    entity_table: "journal_entries",
+    entity_id: entryId,
+    action: "updated",
+    before: {
+      entry: {
+        voucher_type: target.voucher_type,
+        entry_date: target.entry_date,
+        description: target.description,
+      },
+      lines: oldLines.map((l) => ({
+        line_number: l.line_number,
+        account_code: l.account_code,
+        debit: l.debit,
+        credit: l.credit,
+        description: l.description,
+      })),
+    },
+    reason,
+    actor_id: userId,
+    actor_at: new Date(),
+  };
+
+  const hydrated: JournalEntryLine[] = newLines.map((l) => ({
+    ...l,
+    id: genId(),
+    journal_entry_id: entryId,
+  }));
+
+  setState({
+    ..._state,
+    entries: _state.entries.map((e) =>
+      e.id === entryId ? { ...e, ...patch, updated_at: new Date() } : e,
+    ),
+    lines: [..._state.lines.filter((l) => l.journal_entry_id !== entryId), ...hydrated],
+    auditTrails: [..._state.auditTrails, audit],
+  });
+}
+
+function reverseEntry(
+  entryId: string,
+  reason: string,
+  userId: string,
+  entryDate?: string,
+): string | null {
+  const orig = _state.entries.find((e) => e.id === entryId);
+  if (!orig || orig.status !== "posted") return null;
+  const origLines = _state.lines.filter((l) => l.journal_entry_id === entryId);
+
+  const dateISO = entryDate ?? formatDateToISO(new Date());
+  const yyyymmdd = dateISO.replaceAll("-", "");
+  const seq = nextVoucherSeq(_state, orig.client_id, yyyymmdd);
+  const voucher_no = `${yyyymmdd}-${String(seq).padStart(5, "0")}`;
+
+  const newId = genId();
+  const newEntry: JournalEntry = {
+    id: newId,
+    firm_id: orig.firm_id,
+    client_id: orig.client_id,
+    document_id: null,
+    voucher_no,
+    voucher_type: "轉帳",
+    entry_date: dateISO,
+    description: `沖銷 ${orig.voucher_no}：${reason}`,
+    status: "posted",
+    reverses_entry_id: entryId,
+    posted_at: new Date(),
+    posted_by: userId,
+    created_by: userId,
+    created_at: new Date(),
+    updated_at: new Date(),
+  };
+
+  const newLines: JournalEntryLine[] = origLines.map((l) => ({
+    id: genId(),
+    journal_entry_id: newId,
+    line_number: l.line_number,
+    account_code: l.account_code,
+    debit: l.credit,
+    credit: l.debit,
+    description: l.description ? `${l.description}（沖銷）` : null,
+  }));
+
+  const audit: AuditTrail = {
+    id: genId(),
+    firm_id: orig.firm_id,
+    entity_table: "journal_entries",
+    entity_id: entryId,
+    action: "reversed",
+    before: null,
+    reason,
+    actor_id: userId,
+    actor_at: new Date(),
+  };
+
+  setState({
+    ..._state,
+    entries: [
+      ..._state.entries.map((e) =>
+        e.id === entryId ? { ...e, status: "reversed" as const, updated_at: new Date() } : e,
+      ),
+      newEntry,
+    ],
+    lines: [..._state.lines, ...newLines],
+    auditTrails: [..._state.auditTrails, audit],
+  });
+  return newId;
+}
+
+// ---------- Public hook ----------
+
+export interface VoucherDemoStore extends VoucherDemoData {
+  saveDraftEntry: typeof saveDraftEntry;
+  deleteDraftEntry: typeof deleteDraftEntry;
+  postEntries: typeof postEntries;
+  editPostedEntry: typeof editPostedEntry;
+  reverseEntry: typeof reverseEntry;
+  reset: typeof resetVoucherDemoStore;
+}
+
+export function useVoucherDemoStore(): VoucherDemoStore {
+  const state = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  return {
+    ...state,
+    saveDraftEntry,
+    deleteDraftEntry,
+    postEntries,
+    editPostedEntry,
+    reverseEntry,
+    reset: resetVoucherDemoStore,
+  };
+}
+
+// Non-hook accessor for test code that doesn't run inside React.
+export function getVoucherDemoStateForTests(): VoucherDemoData {
+  return _state;
+}

--- a/lib/domain/audit-trail.ts
+++ b/lib/domain/audit-trail.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+
+export const AUDIT_ACTION = [
+  "created",
+  "updated",
+  "deleted",
+  "posted",
+  "voided",
+  "marked_duplicate",
+  "reversed",
+] as const;
+
+export const AUDIT_ENTITY_TABLE = [
+  "journal_entries",
+  "journal_entry_lines",
+  "documents",
+  "invoices",
+  "allowances",
+] as const;
+
+export const auditTrailSchema = z.object({
+  id: z.string().uuid(),
+  firm_id: z.string().uuid(),
+  entity_table: z.enum(AUDIT_ENTITY_TABLE),
+  entity_id: z.string().uuid(),
+  action: z.enum(AUDIT_ACTION),
+  before: z.unknown().nullable().optional(),
+  reason: z.string().nullable().optional(),
+  actor_id: z.string().uuid().nullable().optional(), // NULL 表示系統動作
+  actor_at: z.coerce.date(),
+});
+
+export type AuditAction = (typeof AUDIT_ACTION)[number];
+export type AuditEntityTable = (typeof AUDIT_ENTITY_TABLE)[number];
+export type AuditTrail = z.infer<typeof auditTrailSchema>;

--- a/lib/domain/audit-trail.ts
+++ b/lib/domain/audit-trail.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { ACCOUNT_CODE_REGEX, VOUCHER_TYPE } from "./journal-entry";
+
 export const AUDIT_ACTION = [
   "created",
   "updated",
@@ -18,13 +20,35 @@ export const AUDIT_ENTITY_TABLE = [
   "allowances",
 ] as const;
 
+// Snapshot of an entry's pre-change state, written when entity_table=journal_entries.
+// Other entity_tables will get their own snapshot variants when they grow audit support;
+// at that point this becomes a discriminated union keyed on entity_table.
+export const beforeSnapshotEntryFieldsSchema = z.object({
+  voucher_type: z.enum(VOUCHER_TYPE).optional(),
+  entry_date: z.string().optional(),
+  description: z.string().nullable().optional(),
+});
+
+export const beforeSnapshotLineSchema = z.object({
+  line_number: z.number().int().min(1),
+  account_code: z.string().regex(ACCOUNT_CODE_REGEX),
+  debit: z.number().int().nonnegative(),
+  credit: z.number().int().nonnegative(),
+  description: z.string().nullable().optional(),
+});
+
+export const beforeSnapshotSchema = z.object({
+  entry: beforeSnapshotEntryFieldsSchema.optional(),
+  lines: z.array(beforeSnapshotLineSchema).optional(),
+});
+
 export const auditTrailSchema = z.object({
   id: z.string().uuid(),
   firm_id: z.string().uuid(),
   entity_table: z.enum(AUDIT_ENTITY_TABLE),
   entity_id: z.string().uuid(),
   action: z.enum(AUDIT_ACTION),
-  before: z.unknown().nullable().optional(),
+  before: beforeSnapshotSchema.nullable().optional(),
   reason: z.string().nullable().optional(),
   actor_id: z.string().uuid().nullable().optional(), // NULL 表示系統動作
   actor_at: z.coerce.date(),
@@ -32,4 +56,5 @@ export const auditTrailSchema = z.object({
 
 export type AuditAction = (typeof AUDIT_ACTION)[number];
 export type AuditEntityTable = (typeof AUDIT_ENTITY_TABLE)[number];
+export type BeforeSnapshot = z.infer<typeof beforeSnapshotSchema>;
 export type AuditTrail = z.infer<typeof auditTrailSchema>;

--- a/lib/domain/document.ts
+++ b/lib/domain/document.ts
@@ -1,0 +1,40 @@
+import { z } from "zod";
+
+// v1 only uses `invoice` / `allowance`; rest reserved for v2+ (receipt, payroll, insurance, manual).
+export const DOC_TYPE = [
+  "invoice",
+  "allowance",
+  "receipt",
+  "payroll",
+  "insurance",
+  "manual",
+] as const;
+
+export const DOC_STATUS = ["active", "duplicate", "void", "deleted"] as const;
+
+export const DOC_VAT_TYPE = ["VAT", "NON_VAT"] as const;
+
+export const DOC_OCR_STATUS = ["pending", "done", "failed"] as const;
+
+export const documentSchema = z.object({
+  id: z.string().uuid(),
+  firm_id: z.string().uuid(),
+  client_id: z.string().uuid(),
+  doc_date: z.string(), // YYYY-MM-DD
+  type: z.enum(DOC_VAT_TYPE),
+  doc_type: z.enum(DOC_TYPE),
+  file_url: z.string().nullable().optional(),
+  ocr_status: z.enum(DOC_OCR_STATUS).nullable().optional(),
+  amount: z.number().int().nullable().optional(),
+  duplicate_of: z.string().uuid().nullable().optional(),
+  status: z.enum(DOC_STATUS).default("active"),
+  created_by: z.string().uuid(),
+  created_at: z.coerce.date(),
+  updated_at: z.coerce.date(),
+});
+
+export type DocType = (typeof DOC_TYPE)[number];
+export type DocStatus = (typeof DOC_STATUS)[number];
+export type DocVatType = (typeof DOC_VAT_TYPE)[number];
+export type DocOcrStatus = (typeof DOC_OCR_STATUS)[number];
+export type Document = z.infer<typeof documentSchema>;

--- a/lib/domain/journal-entry.ts
+++ b/lib/domain/journal-entry.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+
+export const VOUCHER_TYPE = ["收入", "支出", "轉帳"] as const;
+
+export const ENTRY_STATUS = ["draft", "posted", "reversed"] as const;
+
+// Mirrors §3.4 DB CHECK: each line must be debit-only or credit-only.
+export const journalEntryLineSchema = z
+  .object({
+    id: z.string().uuid(),
+    journal_entry_id: z.string().uuid(),
+    line_number: z.number().int().min(1),
+    account_code: z.string().regex(/^\d{4}$/, "科目代碼為 4 位數字"),
+    debit: z.number().int().nonnegative().default(0),
+    credit: z.number().int().nonnegative().default(0),
+    description: z.string().nullable().optional(),
+  })
+  .refine((line) => (line.debit > 0) !== (line.credit > 0), {
+    message: "借方與貸方只能擇一為正",
+  });
+
+// Mirrors §3.3 DB CHECK: posted/reversed must carry a voucher_no.
+export const journalEntrySchema = z
+  .object({
+    id: z.string().uuid(),
+    firm_id: z.string().uuid(),
+    client_id: z.string().uuid(),
+    document_id: z.string().uuid().nullable().optional(),
+    voucher_no: z
+      .string()
+      .regex(/^\d{8}-\d{5}$/, "傳票編號格式錯誤 (YYYYMMDD-NNNNN)")
+      .nullable()
+      .optional(),
+    voucher_type: z.enum(VOUCHER_TYPE),
+    entry_date: z.string(), // YYYY-MM-DD
+    description: z.string().nullable().optional(),
+    status: z.enum(ENTRY_STATUS).default("draft"),
+    reverses_entry_id: z.string().uuid().nullable().optional(),
+    posted_at: z.coerce.date().nullable().optional(),
+    posted_by: z.string().uuid().nullable().optional(),
+    created_by: z.string().uuid().nullable().optional(),
+    created_at: z.coerce.date(),
+    updated_at: z.coerce.date(),
+  })
+  .refine((e) => e.status === "draft" || (e.voucher_no != null && e.voucher_no.length > 0), {
+    message: "posted/reversed 必須有 voucher_no",
+  });
+
+export const journalEntryWithLinesSchema = z.object({
+  entry: journalEntrySchema,
+  lines: z.array(journalEntryLineSchema),
+});
+
+export type VoucherType = (typeof VOUCHER_TYPE)[number];
+export type EntryStatus = (typeof ENTRY_STATUS)[number];
+export type JournalEntry = z.infer<typeof journalEntrySchema>;
+export type JournalEntryLine = z.infer<typeof journalEntryLineSchema>;
+export type JournalEntryWithLines = z.infer<typeof journalEntryWithLinesSchema>;

--- a/lib/domain/journal-entry.ts
+++ b/lib/domain/journal-entry.ts
@@ -4,13 +4,15 @@ export const VOUCHER_TYPE = ["收入", "支出", "轉帳"] as const;
 
 export const ENTRY_STATUS = ["draft", "posted", "reversed"] as const;
 
+export const ACCOUNT_CODE_REGEX = /^\d{4,6}$/;
+
 // Mirrors §3.4 DB CHECK: each line must be debit-only or credit-only.
 export const journalEntryLineSchema = z
   .object({
     id: z.string().uuid(),
     journal_entry_id: z.string().uuid(),
     line_number: z.number().int().min(1),
-    account_code: z.string().regex(/^\d{4}$/, "科目代碼為 4 位數字"),
+    account_code: z.string().regex(ACCOUNT_CODE_REGEX, "科目代碼為 4–6 位數字"),
     debit: z.number().int().nonnegative().default(0),
     credit: z.number().int().nonnegative().default(0),
     description: z.string().nullable().optional(),
@@ -56,3 +58,43 @@ export type EntryStatus = (typeof ENTRY_STATUS)[number];
 export type JournalEntry = z.infer<typeof journalEntrySchema>;
 export type JournalEntryLine = z.infer<typeof journalEntryLineSchema>;
 export type JournalEntryWithLines = z.infer<typeof journalEntryWithLinesSchema>;
+
+interface LineSums {
+  debit: number;
+  credit: number;
+}
+
+type SumLine = Pick<JournalEntryLine, "debit" | "credit">;
+
+export function sumLines(lines: readonly SumLine[]): LineSums {
+  let debit = 0;
+  let credit = 0;
+  for (const l of lines) {
+    debit += l.debit;
+    credit += l.credit;
+  }
+  return { debit, credit };
+}
+
+export function isLinesBalanced(lines: readonly SumLine[]): boolean {
+  const { debit, credit } = sumLines(lines);
+  return debit === credit && debit > 0;
+}
+
+// Single pass over all lines into a map keyed by journal_entry_id —
+// O(L) build + O(1) per-row lookup, replacing O(rows × L) per-row scans.
+export function buildLineSumsMap(
+  lines: readonly Pick<JournalEntryLine, "journal_entry_id" | "debit" | "credit">[],
+): Map<string, LineSums> {
+  const m = new Map<string, LineSums>();
+  for (const l of lines) {
+    const cur = m.get(l.journal_entry_id);
+    if (cur) {
+      cur.debit += l.debit;
+      cur.credit += l.credit;
+    } else {
+      m.set(l.journal_entry_id, { debit: l.debit, credit: l.credit });
+    }
+  }
+  return m;
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -19,8 +19,10 @@ export function formatDateToISO(date: Date): string {
   return `${year}-${month}-${day}`;
 }
 
+const ntdFormatter = new Intl.NumberFormat("zh-TW");
+
 export function formatNTD(amount: number): string {
-  return amount.toLocaleString();
+  return ntdFormatter.format(amount);
 }
 
 export function normalizeDateInput(value: string | undefined): string | undefined {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -12,6 +12,17 @@ export function formatDateToYYYYMMDD(date: Date): string {
   return `${year}/${month}/${day}`;
 }
 
+export function formatDateToISO(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+export function formatNTD(amount: number): string {
+  return amount.toLocaleString();
+}
+
 export function normalizeDateInput(value: string | undefined): string | undefined {
   if (!value) return undefined;
   const trimmed = value.trim();

--- a/tests/fixtures/voucher-demo-generator.test.ts
+++ b/tests/fixtures/voucher-demo-generator.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+import { generateVoucherDemoData } from "./voucher-demo-generator";
+import { documentSchema } from "@/lib/domain/document";
+import {
+  journalEntrySchema,
+  journalEntryLineSchema,
+} from "@/lib/domain/journal-entry";
+import { auditTrailSchema } from "@/lib/domain/audit-trail";
+
+describe("voucher-demo-generator", () => {
+  it("emits documents that parse cleanly through documentSchema", () => {
+    const data = generateVoucherDemoData();
+    for (const d of data.documents) {
+      expect(() => documentSchema.parse(d)).not.toThrow();
+    }
+  });
+
+  it("emits journal entries that parse cleanly through journalEntrySchema", () => {
+    const data = generateVoucherDemoData();
+    for (const e of data.entries) {
+      expect(() => journalEntrySchema.parse(e)).not.toThrow();
+    }
+  });
+
+  it("emits journal entry lines that parse cleanly through journalEntryLineSchema", () => {
+    const data = generateVoucherDemoData();
+    for (const l of data.lines) {
+      expect(() => journalEntryLineSchema.parse(l)).not.toThrow();
+    }
+  });
+
+  it("emits audit trails that parse cleanly through auditTrailSchema", () => {
+    const data = generateVoucherDemoData();
+    for (const a of data.auditTrails) {
+      expect(() => auditTrailSchema.parse(a)).not.toThrow();
+    }
+  });
+
+  it("is deterministic — two calls produce identical IDs and content", () => {
+    const a = generateVoucherDemoData();
+    const b = generateVoucherDemoData();
+    expect(a.firmId).toBe(b.firmId);
+    expect(a.clientId).toBe(b.clientId);
+    expect(a.entries.map((e) => e.id)).toEqual(b.entries.map((e) => e.id));
+    expect(a.lines.map((l) => l.id)).toEqual(b.lines.map((l) => l.id));
+    expect(a.documents.map((d) => d.id)).toEqual(b.documents.map((d) => d.id));
+    expect(a.auditTrails.map((t) => t.id)).toEqual(b.auditTrails.map((t) => t.id));
+  });
+
+  it("covers all required UI states", () => {
+    const data = generateVoucherDemoData();
+    const drafts = data.entries.filter((e) => e.status === "draft");
+    const posted = data.entries.filter((e) => e.status === "posted");
+    const reversed = data.entries.filter((e) => e.status === "reversed");
+
+    expect(drafts.length).toBeGreaterThanOrEqual(3);
+    expect(posted.length).toBeGreaterThanOrEqual(5);
+    expect(reversed.length).toBeGreaterThanOrEqual(1);
+
+    // 至少一筆 reversal 連回原 entry
+    const reversalEntries = posted.filter((e) => e.reverses_entry_id != null);
+    expect(reversalEntries.length).toBeGreaterThanOrEqual(1);
+    for (const r of reversalEntries) {
+      const orig = data.entries.find((e) => e.id === r.reverses_entry_id);
+      expect(orig).toBeDefined();
+      expect(orig?.status).toBe("reversed");
+    }
+
+    // 至少一筆 posted-edited（在 audit_trails 留下 'updated' 紀錄）
+    const editedIds = data.auditTrails
+      .filter((a) => a.action === "updated")
+      .map((a) => a.entity_id);
+    expect(editedIds.length).toBeGreaterThanOrEqual(1);
+    for (const id of editedIds) {
+      const e = data.entries.find((x) => x.id === id);
+      expect(e?.status).toBe("posted");
+    }
+
+    // 系統分錄：至少一筆 posted entry 沒有 document_id
+    const systemEntries = posted.filter((e) => e.document_id == null);
+    expect(systemEntries.length).toBeGreaterThanOrEqual(1);
+
+    // 來自 invoice/allowance 的 entry：至少一筆 posted 有 document_id
+    const docDriven = posted.filter((e) => e.document_id != null);
+    expect(docDriven.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("posted entries all carry a voucher_no; drafts carry none", () => {
+    const data = generateVoucherDemoData();
+    for (const e of data.entries) {
+      if (e.status === "draft") {
+        expect(e.voucher_no).toBeNull();
+      } else {
+        expect(e.voucher_no).toMatch(/^\d{8}-\d{5}$/);
+      }
+    }
+  });
+
+  it("every line belongs to an entry that exists", () => {
+    const data = generateVoucherDemoData();
+    const ids = new Set(data.entries.map((e) => e.id));
+    for (const l of data.lines) {
+      expect(ids.has(l.journal_entry_id)).toBe(true);
+    }
+  });
+
+  it("balanced entries: posted entries' debit total equals credit total", () => {
+    const data = generateVoucherDemoData();
+    for (const e of data.entries) {
+      if (e.status !== "posted") continue;
+      const ls = data.lines.filter((l) => l.journal_entry_id === e.id);
+      const debit = ls.reduce((s, l) => s + l.debit, 0);
+      const credit = ls.reduce((s, l) => s + l.credit, 0);
+      expect(debit).toBe(credit);
+      expect(debit).toBeGreaterThan(0);
+    }
+  });
+});

--- a/tests/fixtures/voucher-demo-generator.ts
+++ b/tests/fixtures/voucher-demo-generator.ts
@@ -1,0 +1,440 @@
+import type { Document } from "@/lib/domain/document";
+import type {
+  JournalEntry,
+  JournalEntryLine,
+} from "@/lib/domain/journal-entry";
+import type { AuditTrail } from "@/lib/domain/audit-trail";
+
+export interface VoucherDemoData {
+  firmId: string;
+  clientId: string;
+  userId: string;
+  entries: JournalEntry[];
+  lines: JournalEntryLine[];
+  documents: Document[];
+  auditTrails: AuditTrail[];
+}
+
+// Phase 1 fake data: covers every UI state phase 2 must render.
+// IDs are deterministic counter-based UUIDs so tests can assert exact shapes.
+export function generateVoucherDemoData(): VoucherDemoData {
+  let counter = 0;
+  const nextId = (): string => {
+    counter += 1;
+    return `00000000-0000-4000-8000-${counter.toString(16).padStart(12, "0")}`;
+  };
+
+  const firmId = nextId();
+  const clientId = nextId();
+  const userId = nextId();
+
+  const documents: Document[] = [];
+  const entries: JournalEntry[] = [];
+  const lines: JournalEntryLine[] = [];
+  const auditTrails: AuditTrail[] = [];
+
+  const at = (iso: string): Date => new Date(iso);
+
+  // ---------- Documents (one per VAT-source entry; none for system entries) ----------
+
+  // doc1：進項發票 文具 3,300（→ entry1，posted 無編輯）
+  const doc1Id = nextId();
+  documents.push({
+    id: doc1Id,
+    firm_id: firmId,
+    client_id: clientId,
+    doc_date: "2024-01-15",
+    type: "VAT",
+    doc_type: "invoice",
+    file_url: "demo/invoices/2024-01-15-stationery.pdf",
+    ocr_status: "done",
+    amount: 3300,
+    duplicate_of: null,
+    status: "active",
+    created_by: userId,
+    created_at: at("2024-01-15T09:00:00Z"),
+    updated_at: at("2024-01-15T09:00:00Z"),
+  });
+
+  // doc2：進項發票 旅費 12,600（→ entry2，posted-edited）
+  const doc2Id = nextId();
+  documents.push({
+    id: doc2Id,
+    firm_id: firmId,
+    client_id: clientId,
+    doc_date: "2024-01-20",
+    type: "VAT",
+    doc_type: "invoice",
+    file_url: "demo/invoices/2024-01-20-travel.pdf",
+    ocr_status: "done",
+    amount: 12600,
+    duplicate_of: null,
+    status: "active",
+    created_by: userId,
+    created_at: at("2024-01-20T09:00:00Z"),
+    updated_at: at("2024-01-22T15:30:00Z"),
+  });
+
+  // doc3：進項折讓 1,050（→ entry3，posted）
+  const doc3Id = nextId();
+  documents.push({
+    id: doc3Id,
+    firm_id: firmId,
+    client_id: clientId,
+    doc_date: "2024-02-05",
+    type: "VAT",
+    doc_type: "allowance",
+    file_url: "demo/allowances/2024-02-05.pdf",
+    ocr_status: "done",
+    amount: 1050,
+    duplicate_of: null,
+    status: "active",
+    created_by: userId,
+    created_at: at("2024-02-05T10:00:00Z"),
+    updated_at: at("2024-02-05T10:00:00Z"),
+  });
+
+  // doc4：銷項發票 21,000（→ entry4，後被沖銷）
+  const doc4Id = nextId();
+  documents.push({
+    id: doc4Id,
+    firm_id: firmId,
+    client_id: clientId,
+    doc_date: "2024-02-10",
+    type: "VAT",
+    doc_type: "invoice",
+    file_url: "demo/invoices/2024-02-10-sales.pdf",
+    ocr_status: "done",
+    amount: 21000,
+    duplicate_of: null,
+    status: "active",
+    created_by: userId,
+    created_at: at("2024-02-10T11:00:00Z"),
+    updated_at: at("2024-02-10T11:00:00Z"),
+  });
+
+  // doc5：進項發票 5,250（→ draft1）
+  const doc5Id = nextId();
+  documents.push({
+    id: doc5Id,
+    firm_id: firmId,
+    client_id: clientId,
+    doc_date: "2024-03-01",
+    type: "VAT",
+    doc_type: "invoice",
+    file_url: "demo/invoices/2024-03-01-supplies.pdf",
+    ocr_status: "done",
+    amount: 5250,
+    duplicate_of: null,
+    status: "active",
+    created_by: userId,
+    created_at: at("2024-03-01T08:30:00Z"),
+    updated_at: at("2024-03-01T08:30:00Z"),
+  });
+
+  // doc6：進項發票 1,050（→ draft3，缺科目）
+  const doc6Id = nextId();
+  documents.push({
+    id: doc6Id,
+    firm_id: firmId,
+    client_id: clientId,
+    doc_date: "2024-03-05",
+    type: "VAT",
+    doc_type: "invoice",
+    file_url: "demo/invoices/2024-03-05-misc.pdf",
+    ocr_status: "done",
+    amount: 1050,
+    duplicate_of: null,
+    status: "active",
+    created_by: userId,
+    created_at: at("2024-03-05T14:00:00Z"),
+    updated_at: at("2024-03-05T14:00:00Z"),
+  });
+
+  // ---------- Helper to build a line ----------
+  const makeLine = (args: {
+    journal_entry_id: string;
+    line_number: number;
+    account_code: string;
+    debit?: number;
+    credit?: number;
+    description?: string;
+  }): JournalEntryLine => ({
+    id: nextId(),
+    journal_entry_id: args.journal_entry_id,
+    line_number: args.line_number,
+    account_code: args.account_code,
+    debit: args.debit ?? 0,
+    credit: args.credit ?? 0,
+    description: args.description ?? null,
+  });
+
+  // ---------- Entry 1: posted, 進項可扣抵, doc1 ----------
+  const entry1Id = nextId();
+  entries.push({
+    id: entry1Id,
+    firm_id: firmId,
+    client_id: clientId,
+    document_id: doc1Id,
+    voucher_no: "20240115-00001",
+    voucher_type: "支出",
+    entry_date: "2024-01-15",
+    description: "文具用品 3,300",
+    status: "posted",
+    reverses_entry_id: null,
+    posted_at: at("2024-01-16T10:00:00Z"),
+    posted_by: userId,
+    created_by: userId,
+    created_at: at("2024-01-15T09:00:00Z"),
+    updated_at: at("2024-01-16T10:00:00Z"),
+  });
+  lines.push(
+    makeLine({ journal_entry_id: entry1Id, line_number: 1, account_code: "6133", debit: 3000, description: "文具用品費" }),
+    makeLine({ journal_entry_id: entry1Id, line_number: 2, account_code: "1147", debit: 300, description: "進項稅額" }),
+    makeLine({ journal_entry_id: entry1Id, line_number: 3, account_code: "1111", credit: 3300, description: "現金" }),
+  );
+
+  // ---------- Entry 2: posted-edited, 進項可扣抵, doc2 ----------
+  // 模擬：原始 OCR 抓錯科目（5102 旅費 → 6133 文具用品費），員工 in-place edit 修正
+  const entry2Id = nextId();
+  entries.push({
+    id: entry2Id,
+    firm_id: firmId,
+    client_id: clientId,
+    document_id: doc2Id,
+    voucher_no: "20240120-00001",
+    voucher_type: "支出",
+    entry_date: "2024-01-20",
+    description: "出差旅費 12,600",
+    status: "posted",
+    reverses_entry_id: null,
+    posted_at: at("2024-01-21T11:00:00Z"),
+    posted_by: userId,
+    created_by: userId,
+    created_at: at("2024-01-20T09:00:00Z"),
+    updated_at: at("2024-01-22T15:30:00Z"), // 編輯時間
+  });
+  lines.push(
+    makeLine({ journal_entry_id: entry2Id, line_number: 1, account_code: "5102", debit: 12000, description: "旅費" }),
+    makeLine({ journal_entry_id: entry2Id, line_number: 2, account_code: "1147", debit: 600, description: "進項稅額" }),
+    makeLine({ journal_entry_id: entry2Id, line_number: 3, account_code: "1112", credit: 12600, description: "銀行存款" }),
+  );
+  // audit_trails 紀錄編輯前的 snapshot
+  auditTrails.push({
+    id: nextId(),
+    firm_id: firmId,
+    entity_table: "journal_entries",
+    entity_id: entry2Id,
+    action: "updated",
+    before: {
+      entry: {
+        description: "出差旅費 12,600",
+      },
+      lines: [
+        { line_number: 1, account_code: "6133", debit: 12000, credit: 0, description: "文具用品費（OCR 誤判）" },
+        { line_number: 2, account_code: "1147", debit: 600, credit: 0, description: "進項稅額" },
+        { line_number: 3, account_code: "1112", debit: 0, credit: 12600, description: "銀行存款" },
+      ],
+    },
+    reason: "OCR 將旅費誤判為文具用品費，依實際發票內容修正",
+    actor_id: userId,
+    actor_at: at("2024-01-22T15:30:00Z"),
+  });
+
+  // ---------- Entry 3: posted, 進項折讓, doc3 ----------
+  const entry3Id = nextId();
+  entries.push({
+    id: entry3Id,
+    firm_id: firmId,
+    client_id: clientId,
+    document_id: doc3Id,
+    voucher_no: "20240205-00001",
+    voucher_type: "收入",
+    entry_date: "2024-02-05",
+    description: "進項折讓 1,050",
+    status: "posted",
+    reverses_entry_id: null,
+    posted_at: at("2024-02-06T09:00:00Z"),
+    posted_by: userId,
+    created_by: userId,
+    created_at: at("2024-02-05T10:00:00Z"),
+    updated_at: at("2024-02-06T09:00:00Z"),
+  });
+  lines.push(
+    makeLine({ journal_entry_id: entry3Id, line_number: 1, account_code: "1111", debit: 1050, description: "現金" }),
+    makeLine({ journal_entry_id: entry3Id, line_number: 2, account_code: "6133", credit: 1000, description: "文具用品費（折讓）" }),
+    makeLine({ journal_entry_id: entry3Id, line_number: 3, account_code: "1147", credit: 50, description: "進項稅額（折讓）" }),
+  );
+
+  // ---------- Entry 4: 原本 posted, 後被沖銷, doc4 ----------
+  const entry4Id = nextId();
+  entries.push({
+    id: entry4Id,
+    firm_id: firmId,
+    client_id: clientId,
+    document_id: doc4Id,
+    voucher_no: "20240210-00001",
+    voucher_type: "收入",
+    entry_date: "2024-02-10",
+    description: "銷項收入 21,000（已沖銷）",
+    status: "reversed",
+    reverses_entry_id: null,
+    posted_at: at("2024-02-11T10:00:00Z"),
+    posted_by: userId,
+    created_by: userId,
+    created_at: at("2024-02-10T11:00:00Z"),
+    updated_at: at("2024-02-15T16:00:00Z"),
+  });
+  lines.push(
+    makeLine({ journal_entry_id: entry4Id, line_number: 1, account_code: "1112", debit: 21000, description: "銀行存款" }),
+    makeLine({ journal_entry_id: entry4Id, line_number: 2, account_code: "4101", credit: 20000, description: "營業收入" }),
+    makeLine({ journal_entry_id: entry4Id, line_number: 3, account_code: "2271", credit: 1000, description: "銷項稅額" }),
+  );
+
+  // ---------- Entry 5: 反向分錄（沖銷 entry4），posted, no document ----------
+  const entry5Id = nextId();
+  entries.push({
+    id: entry5Id,
+    firm_id: firmId,
+    client_id: clientId,
+    document_id: null,
+    voucher_no: "20240215-00001",
+    voucher_type: "轉帳",
+    entry_date: "2024-02-15",
+    description: `沖銷 20240210-00001：客戶取消訂單`,
+    status: "posted",
+    reverses_entry_id: entry4Id,
+    posted_at: at("2024-02-15T16:00:00Z"),
+    posted_by: userId,
+    created_by: userId,
+    created_at: at("2024-02-15T16:00:00Z"),
+    updated_at: at("2024-02-15T16:00:00Z"),
+  });
+  lines.push(
+    makeLine({ journal_entry_id: entry5Id, line_number: 1, account_code: "4101", debit: 20000, description: "營業收入（沖銷）" }),
+    makeLine({ journal_entry_id: entry5Id, line_number: 2, account_code: "2271", debit: 1000, description: "銷項稅額（沖銷）" }),
+    makeLine({ journal_entry_id: entry5Id, line_number: 3, account_code: "1112", credit: 21000, description: "銀行存款（沖銷）" }),
+  );
+  // audit_trails 紀錄 entry4 被沖銷
+  auditTrails.push({
+    id: nextId(),
+    firm_id: firmId,
+    entity_table: "journal_entries",
+    entity_id: entry4Id,
+    action: "reversed",
+    before: null,
+    reason: "客戶取消訂單，全額沖銷",
+    actor_id: userId,
+    actor_at: at("2024-02-15T16:00:00Z"),
+  });
+
+  // ---------- Entry 6: 系統分錄（折舊），posted, no document ----------
+  const entry6Id = nextId();
+  entries.push({
+    id: entry6Id,
+    firm_id: firmId,
+    client_id: clientId,
+    document_id: null,
+    voucher_no: "20240228-00001",
+    voucher_type: "轉帳",
+    entry_date: "2024-02-28",
+    description: "二月份折舊（系統自動）",
+    status: "posted",
+    reverses_entry_id: null,
+    posted_at: at("2024-02-28T23:59:00Z"),
+    posted_by: null,
+    created_by: null,
+    created_at: at("2024-02-28T23:59:00Z"),
+    updated_at: at("2024-02-28T23:59:00Z"),
+  });
+  lines.push(
+    makeLine({ journal_entry_id: entry6Id, line_number: 1, account_code: "6173", debit: 5000, description: "折舊費用" }),
+    makeLine({ journal_entry_id: entry6Id, line_number: 2, account_code: "1611", credit: 5000, description: "累計折舊" }),
+  );
+
+  // ---------- Draft 1: balanced, ready to post（doc5）----------
+  const draft1Id = nextId();
+  entries.push({
+    id: draft1Id,
+    firm_id: firmId,
+    client_id: clientId,
+    document_id: doc5Id,
+    voucher_no: null,
+    voucher_type: "支出",
+    entry_date: "2024-03-01",
+    description: "辦公用品 5,250",
+    status: "draft",
+    reverses_entry_id: null,
+    posted_at: null,
+    posted_by: null,
+    created_by: userId,
+    created_at: at("2024-03-01T08:30:00Z"),
+    updated_at: at("2024-03-01T08:30:00Z"),
+  });
+  lines.push(
+    makeLine({ journal_entry_id: draft1Id, line_number: 1, account_code: "6133", debit: 5000, description: "文具用品費" }),
+    makeLine({ journal_entry_id: draft1Id, line_number: 2, account_code: "1147", debit: 250, description: "進項稅額" }),
+    makeLine({ journal_entry_id: draft1Id, line_number: 3, account_code: "1112", credit: 5250, description: "銀行存款" }),
+  );
+
+  // ---------- Draft 2: balanced, manual entry, no document ----------
+  const draft2Id = nextId();
+  entries.push({
+    id: draft2Id,
+    firm_id: firmId,
+    client_id: clientId,
+    document_id: null,
+    voucher_no: null,
+    voucher_type: "收入",
+    entry_date: "2024-03-03",
+    description: "現金銷貨 8,400（無發票，手動建單）",
+    status: "draft",
+    reverses_entry_id: null,
+    posted_at: null,
+    posted_by: null,
+    created_by: userId,
+    created_at: at("2024-03-03T17:00:00Z"),
+    updated_at: at("2024-03-03T17:00:00Z"),
+  });
+  lines.push(
+    makeLine({ journal_entry_id: draft2Id, line_number: 1, account_code: "1111", debit: 8400, description: "現金" }),
+    makeLine({ journal_entry_id: draft2Id, line_number: 2, account_code: "4101", credit: 8000, description: "營業收入" }),
+    makeLine({ journal_entry_id: draft2Id, line_number: 3, account_code: "2271", credit: 400, description: "銷項稅額" }),
+  );
+
+  // ---------- Draft 3: 缺科目（無法 post）（doc6）----------
+  // 用 line_number=1 的 description 標示 "（待補科目）" 但 account_code 為佔位 "9999"
+  const draft3Id = nextId();
+  entries.push({
+    id: draft3Id,
+    firm_id: firmId,
+    client_id: clientId,
+    document_id: doc6Id,
+    voucher_no: null,
+    voucher_type: "支出",
+    entry_date: "2024-03-05",
+    description: "雜支 1,050（科目待補）",
+    status: "draft",
+    reverses_entry_id: null,
+    posted_at: null,
+    posted_by: null,
+    created_by: userId,
+    created_at: at("2024-03-05T14:00:00Z"),
+    updated_at: at("2024-03-05T14:00:00Z"),
+  });
+  lines.push(
+    makeLine({ journal_entry_id: draft3Id, line_number: 1, account_code: "9999", debit: 1000, description: "（待補科目）" }),
+    makeLine({ journal_entry_id: draft3Id, line_number: 2, account_code: "1147", debit: 50, description: "進項稅額" }),
+    makeLine({ journal_entry_id: draft3Id, line_number: 3, account_code: "1111", credit: 1050, description: "現金" }),
+  );
+
+  return {
+    firmId,
+    clientId,
+    userId,
+    entries,
+    lines,
+    documents,
+    auditTrails,
+  };
+}

--- a/tests/fixtures/voucher-demo-generator.ts
+++ b/tests/fixtures/voucher-demo-generator.ts
@@ -17,15 +17,22 @@ export interface VoucherDemoData {
 
 // Phase 1 fake data: covers every UI state phase 2 must render.
 // IDs are deterministic counter-based UUIDs so tests can assert exact shapes.
-export function generateVoucherDemoData(): VoucherDemoData {
+export interface GenerateVoucherDemoDataOptions {
+  firmId?: string;
+  clientId?: string;
+}
+
+export function generateVoucherDemoData(
+  opts: GenerateVoucherDemoDataOptions = {},
+): VoucherDemoData {
   let counter = 0;
   const nextId = (): string => {
     counter += 1;
     return `00000000-0000-4000-8000-${counter.toString(16).padStart(12, "0")}`;
   };
 
-  const firmId = nextId();
-  const clientId = nextId();
+  const firmId = opts.firmId ?? nextId();
+  const clientId = opts.clientId ?? nextId();
   const userId = nextId();
 
   const documents: Document[] = [];
@@ -179,7 +186,7 @@ export function generateVoucherDemoData(): VoucherDemoData {
     voucher_no: "20240115-00001",
     voucher_type: "支出",
     entry_date: "2024-01-15",
-    description: "文具用品 3,300",
+    description: "誠品書店 文具用品採購：A4 影印紙、原子筆、便利貼一批，共 3,300 元（含稅）",
     status: "posted",
     reverses_entry_id: null,
     posted_at: at("2024-01-16T10:00:00Z"),
@@ -205,7 +212,7 @@ export function generateVoucherDemoData(): VoucherDemoData {
     voucher_no: "20240120-00001",
     voucher_type: "支出",
     entry_date: "2024-01-20",
-    description: "出差旅費 12,600",
+    description: "王經理 1/18–1/19 台北↔台中出差：高鐵票、計程車、住宿，共 12,600 元（含稅）",
     status: "posted",
     reverses_entry_id: null,
     posted_at: at("2024-01-21T11:00:00Z"),
@@ -228,7 +235,7 @@ export function generateVoucherDemoData(): VoucherDemoData {
     action: "updated",
     before: {
       entry: {
-        description: "出差旅費 12,600",
+        description: "出差旅費 12,600（OCR 誤抓為文具用品費，後修正）",
       },
       lines: [
         { line_number: 1, account_code: "6133", debit: 12000, credit: 0, description: "文具用品費（OCR 誤判）" },
@@ -251,7 +258,7 @@ export function generateVoucherDemoData(): VoucherDemoData {
     voucher_no: "20240205-00001",
     voucher_type: "收入",
     entry_date: "2024-02-05",
-    description: "進項折讓 1,050",
+    description: "誠品書店 進項折讓：1/15 文具用品退貨一批，折讓金額 1,050 元（含稅）",
     status: "posted",
     reverses_entry_id: null,
     posted_at: at("2024-02-06T09:00:00Z"),
@@ -276,7 +283,7 @@ export function generateVoucherDemoData(): VoucherDemoData {
     voucher_no: "20240210-00001",
     voucher_type: "收入",
     entry_date: "2024-02-10",
-    description: "銷項收入 21,000（已沖銷）",
+    description: "ABC 顧問公司 軟體授權銷售：5 套年度方案，含 5% 營業稅共 21,000 元（已沖銷）",
     status: "reversed",
     reverses_entry_id: null,
     posted_at: at("2024-02-11T10:00:00Z"),
@@ -301,7 +308,7 @@ export function generateVoucherDemoData(): VoucherDemoData {
     voucher_no: "20240215-00001",
     voucher_type: "轉帳",
     entry_date: "2024-02-15",
-    description: `沖銷 20240210-00001：客戶取消訂單`,
+    description: "沖銷 20240210-00001：ABC 顧問公司 2/15 來函取消訂單，全額退款已執行",
     status: "posted",
     reverses_entry_id: entry4Id,
     posted_at: at("2024-02-15T16:00:00Z"),
@@ -338,7 +345,7 @@ export function generateVoucherDemoData(): VoucherDemoData {
     voucher_no: "20240228-00001",
     voucher_type: "轉帳",
     entry_date: "2024-02-28",
-    description: "二月份折舊（系統自動）",
+    description: "二月份折舊（系統自動入帳）：辦公設備 + 電腦設備，依直線法分攤計提 5,000 元",
     status: "posted",
     reverses_entry_id: null,
     posted_at: at("2024-02-28T23:59:00Z"),
@@ -362,7 +369,7 @@ export function generateVoucherDemoData(): VoucherDemoData {
     voucher_no: null,
     voucher_type: "支出",
     entry_date: "2024-03-01",
-    description: "辦公用品 5,250",
+    description: "聯強國際 辦公用品採購：影印紙 10 包、墨水匣 3 組、雜項，共 5,250 元（含稅）",
     status: "draft",
     reverses_entry_id: null,
     posted_at: null,
@@ -387,7 +394,7 @@ export function generateVoucherDemoData(): VoucherDemoData {
     voucher_no: null,
     voucher_type: "收入",
     entry_date: "2024-03-03",
-    description: "現金銷貨 8,400（無發票，手動建單）",
+    description: "3/3 現金銷貨：店面零售收入，無開立發票，含 5% 營業稅共 8,400 元（手動建單）",
     status: "draft",
     reverses_entry_id: null,
     posted_at: null,
@@ -413,7 +420,7 @@ export function generateVoucherDemoData(): VoucherDemoData {
     voucher_no: null,
     voucher_type: "支出",
     entry_date: "2024-03-05",
-    description: "雜支 1,050（科目待補）",
+    description: "雜支 1,050 元（科目待補）：請會計師確認此筆應歸入文具用品費或雜項費用",
     status: "draft",
     reverses_entry_id: null,
     posted_at: null,


### PR DESCRIPTION
## Summary
- **Phase 1 (no DB):** Zod domain models for `documents`, `journal_entries`, `journal_entry_lines`, `audit_trails`; deterministic fake-data generator; `useSyncExternalStore` singleton so UI can iterate without locking schema.
- **Phase 2 (UI):** Voucher list (status tabs, date range / doc-type filter, batch-post checkbox flow with §5.8 friction) + voucher detail page with status-conditional actions; edit dialog (draft / posted modes — `posted` requires reason); reverse dialog; audit-history viewer. Sidebar entry under client submodule. Period page links to draft vouchers from both confirmed invoices and allowances.
- **Phased plan** at `docs/VOUCHER_JOURNAL_ENTRY_PHASED_PLAN.md` so phases 3–11 (financial statements UI, pure deriv functions, schema landing, CTI backfill, RPCs, fiscal-year close) can land as separate PRs.

This PR intentionally ships **no migrations and no service-layer changes**. UI reads / mutates only the in-memory demo store; existing invoice / allowance flows are untouched.

## Test plan
- [ ] `npm run lint` clean
- [ ] `npm run test:run` — 9 fixture tests (schema parse, determinism, balance invariant, voucher_no format, FK integrity) green
- [ ] `npm run dev` — walk through:
  - [ ] `/firm/<firmId>/client/<clientId>/voucher` — filter by status / date / doc-type, paginate, batch-post selection
  - [ ] Click into a draft → edit lines → save → list reflects update
  - [ ] Batch post → confirmation dialog with "我已逐筆檢查" checkbox → posted entries get voucher_no
  - [ ] Edit a posted entry → reason field required → audit-history viewer shows before snapshot
  - [ ] Reverse a posted entry → new reversed entry with bidirectional link
  - [ ] Period page → "已 confirmed 之發票/折讓會產生 draft 傳票 →" link works for both invoice and allowance sections
- [ ] Existing invoice / allowance / period / TET_U export flows still work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)