### PR TITLE
Fix social preview thumbnail pointing at stale Vercel preview

### DIFF
--- a/app/(landing)/page.tsx
+++ b/app/(landing)/page.tsx
@@ -53,21 +53,12 @@ export const metadata: Metadata = {
     url: "https://snapbooks.ai",
     siteName: "SnapBooks.ai",
     type: "website",
-    images: [
-      {
-        url: "https://snapbooks.ai/opengraph-image.png",
-        width: 1200,
-        height: 630,
-        alt: "SnapBooks.ai",
-      },
-    ],
   },
   twitter: {
     card: "summary_large_image",
     title: "AI 記帳事務所推薦｜速博 SnapBooks - 每月$1,260，專業會計師把關",
     description:
       "速博 SnapBooks.ai — 專業會計師全程把關的記帳事務所，每月 NT$1,260 起。拍照上傳憑證就好，記帳報稅全程搞定。適合年營業額 3,000 萬以下中小企業。",
-    images: ["https://snapbooks.ai/twitter-image.png"],
   },
 };
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,9 +6,10 @@ import "./globals.css";
 import { Toaster } from "sonner";
 import { ServiceWorkerRegister } from "@/components/service-worker-register";
 
-const defaultUrl = process.env.VERCEL_URL
-  ? `https://${process.env.VERCEL_URL}`
-  : "http://localhost:3000";
+const defaultUrl =
+  process.env.NODE_ENV === "production"
+    ? "https://snapbooks.ai"
+    : "http://localhost:3000";
 
 export const viewport: Viewport = {
   width: "device-width",


### PR DESCRIPTION
## Summary
- Pin `metadataBase` to `https://snapbooks.ai` in production instead of `VERCEL_URL` — the latter is the per-deployment preview hostname, which (a) causes `og:image` to resolve to a stale preview URL, and (b) sits behind Vercel's preview auth wall, so `facebookexternalhit` got 403.
- Drop the explicit `openGraph.images` / `twitter.images` overrides on the landing page; Next.js auto-injects these from `app/opengraph-image.png` and `app/twitter-image.png` via the file convention, so the explicit entries were duplicates with the wrong (un-hashed) URL.

## Test plan
- [ ] After deploy, view-source on `https://snapbooks.ai` and confirm `<meta property="og:image">` points to `https://snapbooks.ai/opengraph-image.png?...` (not the Vercel preview hostname).
- [ ] Run the [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/) against `https://snapbooks.ai` — expect 200 and the new stacked-check thumbnail.
- [ ] Run the X / Twitter card validator and confirm the `summary_large_image` card renders.
- [ ] Confirm only one `og:image` and one `twitter:image` meta tag in the rendered HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)