### PR TITLE
Use blog cover image as social share thumbnail

### DIFF
--- a/app/(landing)/blog/[slug]/page.tsx
+++ b/app/(landing)/blog/[slug]/page.tsx
@@ -16,6 +16,8 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const post = await getPostBySlug(slug);
   if (!post) return {};
 
+  const imageUrl = post.coverImage ?? "/opengraph-image.png";
+
   return {
     title: `${post.title}｜速博 SnapBooks.ai`,
     description: post.description,
@@ -26,9 +28,13 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       type: "article",
       publishedTime: post.date,
       siteName: "SnapBooks.ai",
-      ...(post.coverImage && {
-        images: [{ url: `https://snapbooks.ai${post.coverImage}`, width: 1200, height: 630 }],
-      }),
+      images: [{ url: imageUrl, width: 1200, height: 630 }],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: post.title,
+      description: post.description,
+      images: [imageUrl],
     },
   };
 }


### PR DESCRIPTION
## Summary
- Posts without a `coverImage` rendered no `og:image` at all because the page's `openGraph` metadata replaced the root file-convention `opengraph-image.png` without supplying its own — Facebook/LINE/Discord previews showed nothing.
- Posts with a `coverImage` set `og:image` correctly, but `twitter:image` still pointed at the site default `/twitter-image.png`, so Twitter/X/Slack previews never used the article cover.
- Now always emit `openGraph.images` and `twitter.images`, using `post.coverImage` when present and falling back to `/opengraph-image.png`.

## Test plan
- [ ] Visit `/blog/business-income-tax-guide` (has cover) — confirm `og:image` and `twitter:image` both point to `/blog/business-income-tax-guide.webp`
- [ ] Visit `/blog/why-ai-accounting-firm-not-saas` (no cover) — confirm both fall back to `/opengraph-image.png`
- [ ] Paste a blog URL into Facebook Sharing Debugger / Twitter Card Validator / LINE chat after deploy and confirm the cover image renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)