### PR TITLE
Exclude robots.txt and sitemap.xml from auth middleware

### DIFF
--- a/lib/supabase/proxy.ts
+++ b/lib/supabase/proxy.ts
@@ -2,6 +2,22 @@ import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
 import { hasEnvVars } from "../utils";
 
+// When adding public landing pages, add them here to skip auth redirect.
+// Use the set for exact paths; use startsWith checks below for prefixes.
+const publicRoutes = new Set([
+  "/",
+  "/terms",
+  "/privacy",
+  "/company",
+  "/blog",
+  "/tools",
+  "/faq",
+  "/startup-guide",
+  "/pricing",
+  "/apply",
+  "/api/webhooks",
+]);
+
 export async function updateSession(request: NextRequest) {
   let supabaseResponse = NextResponse.next({
     request,
@@ -13,12 +29,13 @@ export async function updateSession(request: NextRequest) {
     return supabaseResponse;
   }
 
-  // When adding public landing pages, add them here to skip auth redirect.
-  // Use the array for exact paths; use startsWith checks below for prefixes.
-  const publicRoutes = ["/", "/terms", "/privacy", "/company", "/blog", "/tools", "/faq", "/startup-guide", "/pricing", "/apply"];
   const pathname = request.nextUrl.pathname;
+  const normalizedPath =
+    pathname.length > 1 && pathname.endsWith("/")
+      ? pathname.slice(0, -1)
+      : pathname;
   const isPublic =
-    publicRoutes.includes(pathname) ||
+    publicRoutes.has(normalizedPath) ||
     pathname.startsWith("/blog/") ||
     pathname.startsWith("/tools/") ||
     pathname.startsWith("/api/webhooks/");

--- a/lib/supabase/proxy.ts
+++ b/lib/supabase/proxy.ts
@@ -13,6 +13,24 @@ export async function updateSession(request: NextRequest) {
     return supabaseResponse;
   }
 
+  // When adding public landing pages, add them here to skip auth redirect.
+  // Use the array for exact paths; use startsWith checks below for prefixes.
+  const publicRoutes = ["/", "/terms", "/privacy", "/company", "/blog", "/tools", "/faq", "/startup-guide", "/pricing", "/apply"];
+  const pathname = request.nextUrl.pathname;
+  const isPublic =
+    publicRoutes.includes(pathname) ||
+    pathname.startsWith("/blog/") ||
+    pathname.startsWith("/tools/") ||
+    pathname.startsWith("/api/webhooks/");
+
+  // Skip the Supabase round-trip on public marketing/content routes so they
+  // can serve from the Vercel edge cache. The auth client otherwise sets
+  // `Cache-Control: private, no-store` and forces a Lambda render on every
+  // crawler hit, which both hurts performance and trips bot mitigation.
+  if (isPublic) {
+    return supabaseResponse;
+  }
+
   // With Fluid compute, don't put this client in a global environment
   // variable. Always create a new one on each request.
   const supabase = createServerClient(
@@ -47,18 +65,10 @@ export async function updateSession(request: NextRequest) {
   const { data } = await supabase.auth.getClaims();
   const user = data?.claims;
 
-  // When adding public landing pages, add them here to skip auth redirect.
-  // Use the array for exact paths; use startsWith checks below for prefixes.
-  const publicRoutes = ["/", "/terms", "/privacy", "/company", "/blog", "/tools", "/faq", "/startup-guide", "/pricing", "/apply"];
-
   if (
-    !publicRoutes.includes(request.nextUrl.pathname) &&
-    !request.nextUrl.pathname.startsWith("/blog/") &&
-    !request.nextUrl.pathname.startsWith("/tools/") &&
-    !request.nextUrl.pathname.startsWith("/api/webhooks/") &&
     !user &&
-    !request.nextUrl.pathname.startsWith("/login") &&
-    !request.nextUrl.pathname.startsWith("/auth")
+    !pathname.startsWith("/login") &&
+    !pathname.startsWith("/auth")
   ) {
     // no user, potentially respond by redirecting the user to the login page
     const url = request.nextUrl.clone();
@@ -75,7 +85,6 @@ export async function updateSession(request: NextRequest) {
 
     if (profile?.role === "client" && profile.firm_id && profile.client_id) {
       const expectedPortalPath = `/firm/${profile.firm_id}/client/${profile.client_id}/portal`;
-      const pathname = request.nextUrl.pathname;
       const isPortalPath = pathname === expectedPortalPath || pathname.startsWith(`${expectedPortalPath}/`);
 
       if (

--- a/proxy.ts
+++ b/proxy.ts
@@ -11,10 +11,13 @@ export const config = {
      * Match all request paths except:
      * - _next/static (static files)
      * - _next/image (image optimization files)
-     * - favicon.ico (favicon file)
+     * - favicon.ico, manifest.json, sw.js
+     * - robots.txt, sitemap.xml — crawlers fetch these unauthenticated;
+     *   running them through the auth middleware redirects them to /auth/login,
+     *   which the Facebook scraper interprets as a robots.txt block.
      * - images - .svg, .png, .jpg, .jpeg, .gif, .webp
      * Feel free to modify this pattern to include more paths.
      */
-    "/((?!_next/static|_next/image|favicon.ico|manifest\\.json|sw\\.js|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+    "/((?!_next/static|_next/image|favicon.ico|manifest\\.json|sw\\.js|robots\\.txt|sitemap\\.xml|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
   ],
 };


### PR DESCRIPTION
## Summary
- `/robots.txt` and `/sitemap.xml` were being run through the Supabase auth proxy and 307'd to `/auth/login` for unauthenticated crawlers. Facebook always fetches `/robots.txt` first and interpreted the redirect as a crawl block, so every share preview failed with a 403 in the Sharing Debugger ("This response code could be due to a robots.txt block. Please allowlist facebookexternalhit") even though the page itself returned valid OG tags. LinkedIn worked because it doesn't pre-check robots.txt.
- Added `robots\.txt` and `sitemap\.xml` to the proxy matcher's negative lookahead so crawler-targeted files bypass the middleware entirely.
- Also early-return in `updateSession` for public marketing routes (`/`, `/blog`, `/tools`, `/terms`, etc.) so they serve from the Vercel edge cache instead of forcing a Lambda render with `Cache-Control: private, no-store` on every crawler hit.

## Test plan
- [ ] Deploy and confirm `curl -I https://snapbooks.ai/robots.txt` returns `200` (not `307` to `/auth/login`)
- [ ] Same for `https://snapbooks.ai/sitemap.xml`
- [ ] Hit "Scrape Again" in the [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/) for a blog post URL and verify the real OG title, description, and cover image render
- [ ] Verify a logged-out visitor to `/blog/owner-labor-health-insurance` sees `x-vercel-cache: HIT` (was `BYPASS`)
- [ ] Verify a logged-out visit to `/firm/...` still redirects to `/auth/login`
- [ ] Verify a client-role user visiting `/firm/...` still redirects to their portal path

🤖 Generated with [Claude Code](https://claude.com/claude-code)