### PR TITLE
Prep /apply for Google Ads: Turnstile + conversion tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,12 @@ NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=your-publishable-or-anon-key
 # Google Analytics 4
 NEXT_PUBLIC_GA_ID=G-XXXXXXXXXX
 
+# Cloudflare Turnstile (spam protection on /apply form)
+# Create a site at https://dash.cloudflare.com/?to=/:account/turnstile
+# If unset, the widget is hidden and server-side verification is skipped (dev).
+NEXT_PUBLIC_TURNSTILE_SITE_KEY=
+TURNSTILE_SECRET_KEY=
+
 # LINE Messaging API
 LINE_CHANNEL_SECRET=your-channel-secret
 LINE_CHANNEL_ACCESS_TOKEN=your-channel-access-token

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -57,9 +57,6 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="zh-Hant" suppressHydrationWarning>
-      {process.env.NEXT_PUBLIC_GA_ID && (
-        <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_ID} />
-      )}
       <body className={`${geistSans.className} ${notoSerifTC.variable} antialiased`}>
         <ThemeProvider
           attribute="class"
@@ -71,6 +68,9 @@ export default function RootLayout({
           <Toaster />
           <ServiceWorkerRegister />
         </ThemeProvider>
+        {process.env.NEXT_PUBLIC_GA_ID && (
+          <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_ID} />
+        )}
       </body>
     </html>
   );

--- a/components/apply-form-client.tsx
+++ b/components/apply-form-client.tsx
@@ -15,9 +15,16 @@ import {
   AccordionTrigger,
 } from "@/components/ui/accordion";
 
-import { submitApplyForm, type ApplyFormData } from "@/lib/actions/apply";
+import {
+  submitApplyForm,
+  type ApplyFormData,
+  type ApplyFormPath,
+} from "@/lib/actions/apply";
 import { trackApplySubmit } from "@/lib/analytics";
 import { REGISTRATION_PRICING_NOTE, PRICES, LINE_URL } from "@/lib/pricing";
+import { Turnstile } from "@/components/turnstile";
+
+const TURNSTILE_SITE_KEY = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
 
 // ── Registration path: "我們會為您處理的事項" checklist ──────────────
 const REGISTRATION_STEPS = [
@@ -60,7 +67,7 @@ const BOOKKEEPING_FAQS = [
 ];
 
 export function ApplyFormClient() {
-  const [path, setPath] = useState<"registration" | "bookkeeping" | null>(null);
+  const [path, setPath] = useState<ApplyFormPath | null>(null);
   const [isPending, startTransition] = useTransition();
   const [result, setResult] = useState<{ leadCode: string } | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -93,6 +100,9 @@ export function ApplyFormClient() {
   const [phone, setPhone] = useState("");
   const [notes, setNotes] = useState("");
 
+  // Turnstile token (only required if site key is configured)
+  const [turnstileToken, setTurnstileToken] = useState("");
+
   function handleCopyCode() {
     if (!result?.leadCode) return;
     navigator.clipboard.writeText(result.leadCode);
@@ -109,12 +119,18 @@ export function ApplyFormClient() {
       return;
     }
 
+    if (TURNSTILE_SITE_KEY && !turnstileToken) {
+      setError("請完成人機驗證");
+      return;
+    }
+
     const formData: ApplyFormData = {
       path,
       contactName: contactName.trim(),
       email: email.trim(),
       phone: phone.trim(),
       notes: notes.trim() || undefined,
+      turnstileToken: turnstileToken || undefined,
     };
 
     if (path === "registration") {
@@ -424,6 +440,13 @@ export function ApplyFormClient() {
             </p>
           </div>
 
+          {/* Cloudflare Turnstile (only rendered if a site key is configured) */}
+          {TURNSTILE_SITE_KEY && (
+            <div className="flex justify-center">
+              <Turnstile siteKey={TURNSTILE_SITE_KEY} onVerify={setTurnstileToken} />
+            </div>
+          )}
+
           {/* Error message */}
           {error && (
             <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-base text-red-700">
@@ -434,7 +457,7 @@ export function ApplyFormClient() {
           {/* Submit */}
           <Button
             type="submit"
-            disabled={isPending}
+            disabled={isPending || (!!TURNSTILE_SITE_KEY && !turnstileToken)}
             size="lg"
             className="group w-full rounded-full bg-emerald-600 text-white hover:bg-emerald-500 border-0 h-14 text-lg font-bold shadow-lg shadow-emerald-600/20 transition-all duration-300 hover:shadow-xl hover:shadow-emerald-600/30 hover:-translate-y-0.5 disabled:opacity-50"
           >

--- a/components/turnstile.tsx
+++ b/components/turnstile.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import Script from "next/script";
+
+interface TurnstileRenderOptions {
+  sitekey: string;
+  callback?: (token: string) => void;
+  "error-callback"?: () => void;
+  "expired-callback"?: () => void;
+  theme?: "light" | "dark" | "auto";
+  size?: "normal" | "flexible" | "compact";
+}
+
+declare global {
+  interface Window {
+    turnstile?: {
+      render: (container: HTMLElement, options: TurnstileRenderOptions) => string;
+      reset: (widgetId?: string) => void;
+      remove: (widgetId?: string) => void;
+    };
+  }
+}
+
+export function Turnstile({
+  siteKey,
+  onVerify,
+}: {
+  siteKey: string;
+  onVerify: (token: string) => void;
+}) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const widgetIdRef = useRef<string | null>(null);
+  const onVerifyRef = useRef(onVerify);
+  const [scriptReady, setScriptReady] = useState(false);
+
+  useEffect(() => {
+    onVerifyRef.current = onVerify;
+  }, [onVerify]);
+
+  useEffect(() => {
+    if (!scriptReady || !containerRef.current || !window.turnstile) return;
+    if (widgetIdRef.current) return;
+
+    widgetIdRef.current = window.turnstile.render(containerRef.current, {
+      sitekey: siteKey,
+      callback: (token) => onVerifyRef.current(token),
+      "expired-callback": () => onVerifyRef.current(""),
+      "error-callback": () => onVerifyRef.current(""),
+      theme: "light",
+    });
+
+    return () => {
+      const id = widgetIdRef.current;
+      if (id && window.turnstile) {
+        window.turnstile.remove(id);
+      }
+      widgetIdRef.current = null;
+    };
+  }, [scriptReady, siteKey]);
+
+  return (
+    <>
+      <Script
+        src="https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit"
+        strategy="afterInteractive"
+        onReady={() => setScriptReady(true)}
+      />
+      <div ref={containerRef} />
+    </>
+  );
+}

--- a/lib/actions/apply.ts
+++ b/lib/actions/apply.ts
@@ -2,8 +2,10 @@
 
 import { createAdminClient } from "@/lib/supabase/admin";
 
+export type ApplyFormPath = "registration" | "bookkeeping";
+
 export interface ApplyFormData {
-  path: "registration" | "bookkeeping";
+  path: ApplyFormPath;
   // Contact (both paths)
   contactName: string;
   email: string;
@@ -22,6 +24,8 @@ export interface ApplyFormData {
   taxId?: string;
   currentAccounting?: string;
   monthlyInvoiceVolume?: string;
+  // Bot/spam protection
+  turnstileToken?: string;
 }
 
 export interface ApplyResult {
@@ -41,9 +45,39 @@ function generateLeadCode(): string {
   return `SB-${segment()}-${segment()}`;
 }
 
+// When TURNSTILE_SECRET_KEY is unset (e.g. local dev), verification is skipped.
+async function verifyTurnstile(token: string | undefined): Promise<boolean> {
+  const secret = process.env.TURNSTILE_SECRET_KEY;
+  if (!secret) return true;
+  if (!token) return false;
+
+  try {
+    const res = await fetch(
+      "https://challenges.cloudflare.com/turnstile/v0/siteverify",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({ secret, response: token }),
+        signal: AbortSignal.timeout(8000),
+      },
+    );
+    const data = (await res.json()) as { success?: boolean };
+    return data.success === true;
+  } catch (err) {
+    console.error("Turnstile verification failed:", err);
+    return false;
+  }
+}
+
 export async function submitApplyForm(
   formData: ApplyFormData,
 ): Promise<ApplyResult> {
+  // Bot/spam check first — if Turnstile is configured, fail closed before
+  // running anything else (including DB writes).
+  if (!(await verifyTurnstile(formData.turnstileToken))) {
+    return { success: false, error: "人機驗證失敗，請重新整理頁面後再試" };
+  }
+
   // Validate required fields
   if (!formData.contactName?.trim()) {
     return { success: false, error: "請填寫聯絡人姓名" };
@@ -77,11 +111,12 @@ export async function submitApplyForm(
 
   const leadCode = generateLeadCode();
 
-  // Store all form fields in JSONB data column
-  const { path, ...rest } = formData;
+  // `path` is its own column; `turnstileToken` is single-use and never persisted.
+  const NON_JSONB_FIELDS = new Set<keyof ApplyFormData>(["path", "turnstileToken"]);
   const data = Object.fromEntries(
-    Object.entries(rest).filter(
-      ([, v]) =>
+    Object.entries(formData).filter(
+      ([k, v]) =>
+        !NON_JSONB_FIELDS.has(k as keyof ApplyFormData) &&
         v !== undefined &&
         v !== "" &&
         !(Array.isArray(v) && v.every((s) => s === "")),
@@ -92,7 +127,7 @@ export async function submitApplyForm(
     const supabase = createAdminClient();
     const { error } = await supabase.from("leads").insert({
       lead_code: leadCode,
-      path,
+      path: formData.path,
       data,
     });
 
@@ -102,7 +137,7 @@ export async function submitApplyForm(
         const retryCode = generateLeadCode();
         const { error: retryError } = await supabase.from("leads").insert({
           lead_code: retryCode,
-          path,
+          path: formData.path,
           data,
         });
         if (retryError) {

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,4 +1,5 @@
 import { sendGAEvent } from "@next/third-parties/google";
+import type { ApplyFormPath } from "@/lib/actions/apply";
 
 export function trackCtaClick(location: string) {
   sendGAEvent("event", "cta_click", {
@@ -26,9 +27,20 @@ export function trackAssessmentComplete() {
   sendGAEvent("event", "assessment_complete", {});
 }
 
-export function trackApplySubmit(path: "registration" | "bookkeeping") {
+// Estimated first-year revenue per lead path, used as the conversion value
+// for Google Ads bidding. Tune as real conversion data accumulates.
+//   registration: 商行 setup (NT$6,500) + first-year annual bookkeeping (NT$15,120)
+//   bookkeeping:  first-year annual bookkeeping (NT$15,120)
+const APPLY_CONVERSION_VALUE_TWD: Record<ApplyFormPath, number> = {
+  registration: 21620,
+  bookkeeping: 15120,
+};
+
+export function trackApplySubmit(path: ApplyFormPath) {
   sendGAEvent("event", "apply_submit", {
     apply_path: path,
+    value: APPLY_CONVERSION_VALUE_TWD[path],
+    currency: "TWD",
   });
 }
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
         ...devices["Desktop Chrome"],
         storageState: "tests/e2e/.auth/admin-user.json",
       },
-      testIgnore: /.*\.portal\.spec\.ts/,
+      testIgnore: [/.*\.portal\.spec\.ts/, /.*\.public\.spec\.ts/],
       dependencies: ["setup"],
     },
     {
@@ -31,6 +31,12 @@ export default defineConfig({
       },
       testMatch: /.*\.portal\.spec\.ts/,
       dependencies: ["setup"],
+    },
+    {
+      // Public marketing routes — no auth, no DB seeding.
+      name: "chromium-public-flows",
+      use: { ...devices["Desktop Chrome"] },
+      testMatch: /.*\.public\.spec\.ts/,
     },
   ],
   webServer: {

--- a/tests/e2e/apply-form.public.spec.ts
+++ b/tests/e2e/apply-form.public.spec.ts
@@ -1,0 +1,113 @@
+import { test, expect, type Page } from "@playwright/test";
+
+const HAS_TURNSTILE = !!process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
+
+// Seed window.dataLayer before any page script runs so we can assert on
+// gtag/sendGAEvent calls regardless of whether NEXT_PUBLIC_GA_ID is set in
+// the test environment.
+async function instrumentDataLayer(page: Page) {
+  await page.addInitScript(() => {
+    (window as unknown as { dataLayer: unknown[] }).dataLayer = [];
+  });
+}
+
+async function readApplySubmitEvent(page: Page) {
+  return page.evaluate(() => {
+    type GAEvent = ["event", string, Record<string, unknown>];
+    const dl = (window as unknown as { dataLayer: unknown[] }).dataLayer ?? [];
+    const events: GAEvent[] = dl.map((e) => Array.from(e as ArrayLike<unknown>) as GAEvent);
+    return events.find((e) => e[0] === "event" && e[1] === "apply_submit") ?? null;
+  });
+}
+
+// Wait for Turnstile (test site keys auto-pass) so the submit button enables.
+// When Turnstile is not configured the widget is hidden and submit is enabled
+// immediately — so this is a no-op in that case.
+async function waitForSubmitReady(page: Page) {
+  const submitBtn = page.locator("button", { hasText: "送出申請" });
+  await expect(submitBtn).toBeEnabled({ timeout: 15_000 });
+}
+
+async function fillContactFields(page: Page) {
+  await page.fill("input#contactName", "E2E 測試");
+  await page.fill("input#email", "e2e-test@example.com");
+  await page.fill("input#phone", "0912345678");
+}
+
+test.describe("Apply form (public)", () => {
+  test.beforeEach(async ({ page }) => {
+    await instrumentDataLayer(page);
+  });
+
+  test("renders hero, path selection, and Turnstile widget when configured", async ({
+    page,
+  }) => {
+    await page.goto("/apply");
+
+    await expect(page.locator("h1", { hasText: "合作申請" })).toBeVisible();
+    await expect(page.locator("button", { hasText: "還沒有統編" })).toBeVisible();
+    await expect(page.locator("button", { hasText: "已經有統編" })).toBeVisible();
+
+    if (HAS_TURNSTILE) {
+      // Choose a path so the rest of the form (and Turnstile) renders.
+      await page.locator("button", { hasText: "已經有統編" }).click();
+      await expect(
+        page.locator('iframe[src*="challenges.cloudflare.com"]'),
+      ).toBeVisible({ timeout: 15_000 });
+    }
+  });
+
+  test("bookkeeping submission fires apply_submit with value=15120", async ({
+    page,
+  }) => {
+    await page.goto("/apply");
+
+    await page.locator("button", { hasText: "已經有統編" }).click();
+    await page.fill("input#companyName", "速博測試有限公司");
+    await page.fill("input#taxId", "12345678");
+    await fillContactFields(page);
+
+    await waitForSubmitReady(page);
+    await page.locator("button", { hasText: "送出申請" }).click();
+
+    await expect(page.locator("text=申請已送出")).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(
+      page.locator("text=/SB-[A-Z0-9]{4}-[A-Z0-9]{4}/").first(),
+    ).toBeVisible();
+
+    const event = await readApplySubmitEvent(page);
+    expect(event).not.toBeNull();
+    expect(event?.[2]).toMatchObject({
+      apply_path: "bookkeeping",
+      value: 15120,
+      currency: "TWD",
+    });
+  });
+
+  test("registration submission fires apply_submit with value=21620", async ({
+    page,
+  }) => {
+    await page.goto("/apply");
+
+    await page.locator("button", { hasText: "還沒有統編" }).click();
+    // Registration path has no required company fields — only contact.
+    await fillContactFields(page);
+
+    await waitForSubmitReady(page);
+    await page.locator("button", { hasText: "送出申請" }).click();
+
+    await expect(page.locator("text=申請已送出")).toBeVisible({
+      timeout: 15_000,
+    });
+
+    const event = await readApplySubmitEvent(page);
+    expect(event).not.toBeNull();
+    expect(event?.[2]).toMatchObject({
+      apply_path: "registration",
+      value: 21620,
+      currency: "TWD",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add Cloudflare Turnstile to the `/apply` lead form (env-gated; dev still works without setup). Server action verifies the token first, with an 8s fetch timeout.
- `apply_submit` GA4 event now carries `value` (TWD) + `currency` so it can be imported into Google Ads as a bid-able conversion. Defaults: registration NT$21,620, bookkeeping NT$15,120 — placeholder estimates, tune as real close rates accrue.
- Fix `<GoogleAnalytics>` placement in `app/layout.tsx` — was a direct child of `<html>` (invalid HTML position), now inside `<body>`.
- New `chromium-public-flows` Playwright project (no auth, no DB seeding) plus `apply-form.public.spec.ts` regression test that asserts the conversion-event payload.

## Why
Pre-work before pointing paid Google Ads traffic at `/apply`. Without spam protection a bidding model trained on bot conversions will burn budget; without `value`/`currency` we can't use Maximize Conversion Value bidding later.

## Activation steps (out of band, no code)
1. Cloudflare dashboard → Turnstile → add `snapbooks.ai` (Managed mode), copy site + secret keys into Vercel env.
2. GA4 Admin → Events → mark `apply_submit` as a key event; wait ~24h.
3. Link Google Ads ↔ GA4, then import `apply_submit` as a conversion in Ads.

## Test plan
- [x] `npm run lint` clean (only one pre-existing unrelated warning)
- [x] `npx playwright test apply-form.public --project=chromium-public-flows` — 3/3 passing in ~9s
- [x] Manual: form submits with always-pass test key; submit blocked + lead not inserted with always-fail key
- [ ] Verify on Vercel preview that GA4 DebugView shows `apply_submit` with `value` + `currency`
- [ ] Confirm Turnstile widget renders + auto-passes with real production site key

🤖 Generated with [Claude Code](https://claude.com/claude-code)